### PR TITLE
mavlink: replace TIMESYNC with SYSTEM_TIME in custom MAVLink mode

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1684,7 +1684,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 
 	case MAVLINK_MODE_CUSTOM:
 		configure_stream_local("ATTITUDE", 10.0f);
-		configure_stream_local("TIMESYNC", 10.0f);
+		configure_stream_local("SYSTEM_TIME", 1.0f);
 		break;
 
 	case MAVLINK_MODE_CONFIG: // USB


### PR DESCRIPTION
Third attempt, this time it is tested i in advance, so it should work.