### PR TITLE
Add support for geofences with individual actions and maximum altitude

### DIFF
--- a/msg/geofence_result.msg
+++ b/msg/geofence_result.msg
@@ -1,10 +1,11 @@
 uint64 timestamp                # time since system start (microseconds)
-uint8 GF_ACTION_NONE = 0        # no action on geofence violation
-uint8 GF_ACTION_WARN = 1        # critical mavlink message
-uint8 GF_ACTION_LOITER = 2      # switch to AUTO|LOITER (Hold mode)
-uint8 GF_ACTION_RTL = 3         # switch to AUTO|RTL
-uint8 GF_ACTION_LAND = 4        # switch to AUTO|LAND
-uint8 GF_ACTION_TERMINATE = 5   # flight termination
+uint8 GF_ACTION_DEFAULT = 0     # use action from parameter
+uint8 GF_ACTION_NONE = 1        # no action on geofence violation
+uint8 GF_ACTION_WARN = 2        # critical mavlink message
+uint8 GF_ACTION_LOITER = 3      # switch to AUTO|LOITER (Hold mode)
+uint8 GF_ACTION_RTL = 4         # switch to AUTO|RTL
+uint8 GF_ACTION_LAND = 5        # switch to AUTO|LAND
+uint8 GF_ACTION_TERMINATE = 6   # flight termination
 
 bool geofence_violated          # true if the geofence is violated
 uint8 geofence_action           # action to take when geofence is violated

--- a/msg/geofence_result.msg
+++ b/msg/geofence_result.msg
@@ -1,12 +1,13 @@
 uint64 timestamp                # time since system start (microseconds)
 uint8 GF_ACTION_NONE = 0        # no action on geofence violation
 uint8 GF_ACTION_WARN = 1        # critical mavlink message
-uint8 GF_ACTION_LOITER = 2      # switch to AUTO|LOITER
+uint8 GF_ACTION_LOITER = 2      # switch to AUTO|LOITER (Hold mode)
 uint8 GF_ACTION_RTL = 3         # switch to AUTO|RTL
-uint8 GF_ACTION_TERMINATE = 4   # flight termination
-uint8 GF_ACTION_LAND = 5        # switch to AUTO|LAND
+uint8 GF_ACTION_LAND = 4        # switch to AUTO|LAND
+uint8 GF_ACTION_TERMINATE = 5   # flight termination
 
 bool geofence_violated          # true if the geofence is violated
 uint8 geofence_action           # action to take when geofence is violated
+bool action_required            # fence with action with different than GF_ACTION_NONE exist
 
 bool home_required              # true if the geofence requires a valid home position

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2543,8 +2543,15 @@ Commander::run()
 		    && geofence_action_enabled
 		    && !in_low_battery_failsafe_delay) {
 
+			if (!_geofence_result.geofence_violated) {
+				// keep the previous action to NONE if there is no violation, and use the same fence action multiple times.
+				_geofence_action_prev = geofence_result_s::GF_ACTION_NONE;
+			}
+
 			// check for geofence violation transition
 			if (_geofence_result.geofence_violated && _geofence_action_prev != _geofence_result.geofence_action) {
+
+				_geofence_action_prev = _geofence_result.geofence_action;
 
 				switch (_geofence_result.geofence_action) {
 				case (geofence_result_s::GF_ACTION_NONE) : {
@@ -2601,8 +2608,6 @@ Commander::run()
 					}
 				}
 			}
-
-			_geofence_action_prev = _geofence_result.geofence_action;
 
 			// reset if no longer in LOITER or if manually switched to LOITER
 			const bool in_loiter_mode = _internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LOITER;

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -265,9 +265,6 @@ private:
 		(ParamInt<px4::params::CBRK_VELPOSERR>) _param_cbrk_velposerr,
 		(ParamInt<px4::params::CBRK_VTOLARMING>) _param_cbrk_vtolarming,
 
-		// Geofence
-		(ParamInt<px4::params::GF_ACTION>) _param_geofence_action,
-
 		// Mavlink
 		(ParamInt<px4::params::MAV_COMP_ID>) _param_mav_comp_id,
 		(ParamInt<px4::params::MAV_SYS_ID>) _param_mav_sys_id,
@@ -319,7 +316,7 @@ private:
 	bool		_geofence_rtl_on{false};
 	bool		_geofence_land_on{false};
 	bool		_geofence_warning_action_on{false};
-	bool		_geofence_violated_prev{false};
+	uint8_t		_geofence_action_prev{geofence_result_s::GF_ACTION_NONE};
 
 	bool		_rtl_time_actions_done{false};
 

--- a/src/modules/dataman/dataman.h
+++ b/src/modules/dataman/dataman.h
@@ -83,8 +83,9 @@ struct dataman_compat_s {
 };
 
 /* increment this define whenever a binary incompatible change is performed */
-#define DM_COMPAT_VERSION	2ULL
+#define DM_COMPAT_VERSION	3ULL
 
+#define DM_COMPAT_KEY_2ULL 0x238106188 // old version
 #define DM_COMPAT_KEY ((DM_COMPAT_VERSION << 32) + (sizeof(struct mission_item_s) << 24) + \
 		       (sizeof(struct mission_s) << 16) + (sizeof(struct mission_stats_entry_s) << 12) + \
 		       (sizeof(struct mission_fence_point_s) << 8) + (sizeof(struct mission_safe_point_s) << 4) + \

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -317,6 +317,7 @@ MavlinkMissionManager::send_mission_item(uint8_t sysid, uint8_t compid, uint16_t
 			mission_item.lat = mission_fence_point.lat;
 			mission_item.lon = mission_fence_point.lon;
 			mission_item.altitude = mission_fence_point.alt;
+			mission_item.fence_action = static_cast<float>(mission_fence_point.fence_action);
 
 			if (mission_fence_point.nav_cmd == MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION ||
 			    mission_fence_point.nav_cmd == MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION) {
@@ -1142,6 +1143,7 @@ MavlinkMissionManager::handle_mission_item_both(const mavlink_message_t *msg)
 				mission_fence_point.lat = mission_item.lat;
 				mission_fence_point.lon = mission_item.lon;
 				mission_fence_point.alt = mission_item.altitude;
+				mission_fence_point.fence_action = static_cast<uint8_t>(mission_item.fence_action);
 
 				if (mission_item.nav_cmd == MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION ||
 				    mission_item.nav_cmd == MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION) {
@@ -1442,12 +1444,14 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 		case MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION:
 			mission_item->nav_cmd = (NAV_CMD)mavlink_mission_item->command;
 			mission_item->vertex_count = (uint16_t)(mavlink_mission_item->param1 + 0.5f);
+			mission_item->fence_action = mavlink_mission_item->param3;
 			break;
 
 		case MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION:
 		case MAV_CMD_NAV_FENCE_CIRCLE_EXCLUSION:
 			mission_item->nav_cmd = (NAV_CMD)mavlink_mission_item->command;
 			mission_item->circle_radius = mavlink_mission_item->param1;
+			mission_item->fence_action = mavlink_mission_item->param3;
 			break;
 
 		case MAV_CMD_NAV_RALLY_POINT:
@@ -1724,11 +1728,13 @@ MavlinkMissionManager::format_mavlink_mission_item(const struct mission_item_s *
 		case MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION:
 		case MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION:
 			mavlink_mission_item->param1 = (float)mission_item->vertex_count;
+			mavlink_mission_item->param3 = (float)mission_item->fence_action;
 			break;
 
 		case MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION:
 		case MAV_CMD_NAV_FENCE_CIRCLE_EXCLUSION:
 			mavlink_mission_item->param1 = mission_item->circle_radius;
+			mavlink_mission_item->param3 = (float)mission_item->fence_action;
 			break;
 
 		case MAV_CMD_NAV_RALLY_POINT:

--- a/src/modules/navigator/GeofenceBreachAvoidance/fake_geofence.hpp
+++ b/src/modules/navigator/GeofenceBreachAvoidance/fake_geofence.hpp
@@ -51,7 +51,7 @@ public:
 
 	virtual ~FakeGeofence() {};
 
-	bool isInsidePolygonOrCircle(double lat, double lon, float altitude) override
+	bool isInsideFence(double lat, double lon, float altitude) override
 	{
 		switch (_probe_function_behavior) {
 		case ProbeFunction::ALL_POINTS_OUTSIDE: {

--- a/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.cpp
+++ b/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.cpp
@@ -113,13 +113,13 @@ GeofenceBreachAvoidance::generateLoiterPointForFixedWing(geofence_violation_type
 		waypoint_from_heading_and_distance(_current_pos_lat_lon(0), _current_pos_lat_lon(1), bearing_90_left,
 						   _test_point_distance, &fence_violation_test_point_lat, &fence_violation_test_point_lon);
 
-		const bool left_side_is_inside_fence = geofence->isInsidePolygonOrCircle(fence_violation_test_point_lat,
+		const bool left_side_is_inside_fence = geofence->isInsideFence(fence_violation_test_point_lat,
 						       fence_violation_test_point_lon, _current_alt_amsl);
 
 		waypoint_from_heading_and_distance(_current_pos_lat_lon(0), _current_pos_lat_lon(1), bearing_90_right,
 						   _test_point_distance, &fence_violation_test_point_lat, &fence_violation_test_point_lon);
 
-		const bool right_side_is_inside_fence = geofence->isInsidePolygonOrCircle(fence_violation_test_point_lat,
+		const bool right_side_is_inside_fence = geofence->isInsideFence(fence_violation_test_point_lat,
 							fence_violation_test_point_lon, _current_alt_amsl);
 
 		float bearing_to_loiter_point;
@@ -162,7 +162,7 @@ GeofenceBreachAvoidance::generateLoiterPointForMultirotor(geofence_violation_typ
 		while (abs(current_max - current_min) > 0.5f) {
 			test_point = waypointFromBearingAndDistance(_current_pos_lat_lon, _test_point_bearing, current_distance);
 
-			if (!geofence->isInsidePolygonOrCircle(test_point(0), test_point(1), _current_alt_amsl)) {
+			if (!geofence->isInsideFence(test_point(0), test_point(1), _current_alt_amsl)) {
 				current_max = current_distance;
 
 			} else {

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -110,7 +110,9 @@ public:
 
 	bool isBelowMaxAltitude(float altitude);
 
-	virtual bool isInsidePolygonOrCircle(double lat, double lon, float altitude);
+	virtual bool isInsideFence(double lat, double lon, float altitude);
+
+	bool isMaxAltitudeExceeded();
 
 	int clearDm();
 
@@ -158,7 +160,8 @@ private:
 
 	struct PolygonInfo {
 		uint16_t fence_type;	///< one of MAV_CMD_NAV_FENCE_* (can also be a circular region)
-		uint8_t fence_action; 	///< fence action when this fence is breached
+		uint8_t fence_action;	///< fence action when this fence is breached
+		float max_alt;		///< Maximum altitude (AMSL) for polygon
 		uint16_t dataman_index;
 		union {
 			uint16_t vertex_count;
@@ -178,6 +181,7 @@ private:
 	int _num_polygons{0};
 	bool _has_rtl_action{false}; ///< at least one of the fences has GF_ACTION_RTL
 	bool _action_required{false}; ///< flag indicating if a fence with an action different than GF_ACTION_NONE exists
+	bool _is_max_altitude_exceeded{false}; ///< flag indicating if the vehicle exceeded the maximum allowed altitude for the fence
 
 	MapProjection _projection_reference{}; ///< class to convert (lon, lat) to local [m]
 

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -48,6 +48,7 @@
 #include <lib/geo/geo.h>
 #include <px4_platform_common/defines.h>
 #include <uORB/Subscription.hpp>
+#include <uORB/topics/geofence_result.h>
 #include <uORB/topics/home_position.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_gps_position.h>
@@ -139,12 +140,13 @@ public:
 	bool isEmpty() { return _num_polygons == 0; }
 
 	int getSource() { return _param_gf_source.get(); }
-	int getGeofenceAction() { return _param_gf_action.get(); }
+	uint8_t getGeofenceAction() { return _breached_fence_action; }
 
 	float getMaxHorDistanceHome() { return _param_gf_max_hor_dist.get(); }
 	float getMaxVerDistanceHome() { return _param_gf_max_ver_dist.get(); }
 	bool getPredict() { return _param_gf_predict.get(); }
 
+	bool isActionRequired() { return _action_required; }
 	bool isHomeRequired();
 
 	/**
@@ -155,7 +157,8 @@ public:
 private:
 
 	struct PolygonInfo {
-		uint16_t fence_type; ///< one of MAV_CMD_NAV_FENCE_* (can also be a circular region)
+		uint16_t fence_type;	///< one of MAV_CMD_NAV_FENCE_* (can also be a circular region)
+		uint8_t fence_action; 	///< fence action when this fence is breached
 		uint16_t dataman_index;
 		union {
 			uint16_t vertex_count;
@@ -173,6 +176,8 @@ private:
 	float _altitude_max{0.0f};
 
 	int _num_polygons{0};
+	bool _has_rtl_action{false}; ///< at least one of the fences has GF_ACTION_RTL
+	bool _action_required{false}; ///< flag indicating if a fence with an action different than GF_ACTION_NONE exists
 
 	MapProjection _projection_reference{}; ///< class to convert (lon, lat) to local [m]
 
@@ -180,6 +185,8 @@ private:
 
 	int _outside_counter{0};
 	uint16_t _update_counter{0}; ///< dataman update counter: if it does not match, we polygon data was updated
+
+	uint8_t _breached_fence_action{geofence_result_s::GF_ACTION_NONE}; ///< Most severe fence action from the breached fence
 
 	/**
 	 * implementation of updateFence(), but without locking
@@ -217,7 +224,6 @@ private:
 	bool insideCircle(const PolygonInfo &polygon, double lat, double lon, float altitude);
 
 	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::GF_ACTION>)         _param_gf_action,
 		(ParamInt<px4::params::GF_ALTMODE>)        _param_gf_altmode,
 		(ParamInt<px4::params::GF_SOURCE>)         _param_gf_source,
 		(ParamInt<px4::params::GF_COUNT>)          _param_gf_count,

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -78,6 +78,16 @@ public:
 		GF_SOURCE_GPS = 1
 	};
 
+	/* Legacy actions from parameters */
+	enum {
+		GF_PARAM_ACTION_NONE = 0,
+		GF_PARAM_ACTION_WARNING = 1,
+		GF_PARAM_ACTION_HOLD_MODE = 2,
+		GF_PARAM_ACTION_RETURN_MODE = 3,
+		GF_PARAM_ACTION_TERMINATE = 4,
+		GF_PARAM_ACTION_LAND_MODE = 5
+	};
+
 	/**
 	 * update the geofence from dataman.
 	 * It's generally not necessary to call this as it will automatically update when the data is changed.
@@ -142,13 +152,14 @@ public:
 	bool isEmpty() { return _num_polygons == 0; }
 
 	int getSource() { return _param_gf_source.get(); }
-	uint8_t getGeofenceAction() { return _breached_fence_action; }
+	uint8_t getGeofenceAction();
 
 	float getMaxHorDistanceHome() { return _param_gf_max_hor_dist.get(); }
 	float getMaxVerDistanceHome() { return _param_gf_max_ver_dist.get(); }
 	bool getPredict() { return _param_gf_predict.get(); }
 
-	bool isActionRequired() { return _action_required; }
+	uint8_t legacyActionTranslator(uint8_t param_action);
+	bool isActionRequired();
 	bool isHomeRequired();
 
 	/**
@@ -190,7 +201,7 @@ private:
 	int _outside_counter{0};
 	uint16_t _update_counter{0}; ///< dataman update counter: if it does not match, we polygon data was updated
 
-	uint8_t _breached_fence_action{geofence_result_s::GF_ACTION_NONE}; ///< Most severe fence action from the breached fence
+	uint8_t _breached_fence_action{geofence_result_s::GF_ACTION_DEFAULT}; ///< Most severe fence action from the breached fence
 
 	/**
 	 * implementation of updateFence(), but without locking
@@ -227,7 +238,10 @@ private:
 	 */
 	bool insideCircle(const PolygonInfo &polygon, double lat, double lon, float altitude);
 
+	static constexpr int32_t DISABLED_MAX_ALTITUDE_CHECK = 0;
+
 	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::GF_ACTION>)         _param_geofence_action,
 		(ParamInt<px4::params::GF_ALTMODE>)        _param_gf_altmode,
 		(ParamInt<px4::params::GF_SOURCE>)         _param_gf_source,
 		(ParamInt<px4::params::GF_COUNT>)          _param_gf_count,

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -152,6 +152,7 @@ public:
 	bool isEmpty() { return _num_polygons == 0; }
 
 	int getSource() { return _param_gf_source.get(); }
+	void resetGeofenceAction() { _breached_fence_action = geofence_result_s::GF_ACTION_DEFAULT; }
 	uint8_t getGeofenceAction();
 
 	float getMaxHorDistanceHome() { return _param_gf_max_hor_dist.get(); }

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -44,27 +44,6 @@
  */
 
 /**
- * Geofence violation action.
- *
- * Note: Setting this value to 4 enables flight termination,
- * which will kill the vehicle on violation of the fence.
- * Due to the inherent danger of this, this function is
- * disabled using a software circuit breaker, which needs
- * to be reset to 0 to really shut down the system.
- *
- * @min 0
- * @max 5
- * @value 0 None
- * @value 1 Warning
- * @value 2 Hold mode
- * @value 3 Return mode
- * @value 4 Terminate
- * @value 5 Land mode
- * @group Geofence
- */
-PARAM_DEFINE_INT32(GF_ACTION, 2);
-
-/**
  * Geofence altitude mode
  *
  * Select which altitude (AMSL) source should be used for geofence calculations.

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -44,6 +44,27 @@
  */
 
 /**
+ * Geofence violation action.
+ *
+ * Note: Setting this value to 4 enables flight termination,
+ * which will kill the vehicle on violation of the fence.
+ * Due to the inherent danger of this, this function is
+ * disabled using a software circuit breaker, which needs
+ * to be reset to 0 to really shut down the system.
+ *
+ * @min 0
+ * @max 5
+ * @value 0 None
+ * @value 1 Warning
+ * @value 2 Hold mode
+ * @value 3 Return mode
+ * @value 4 Terminate
+ * @value 5 Land mode
+ * @group Geofence
+ */
+PARAM_DEFINE_INT32(GF_ACTION, 2);
+
+/**
  * Geofence altitude mode
  *
  * Select which altitude (AMSL) source should be used for geofence calculations.

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -162,7 +162,10 @@ struct mission_item_s {
 				float circle_radius;		/**< geofence circle radius in meters (only used for NAV_CMD_NAV_FENCE_CIRCLE*) */
 			};
 			float acceptance_radius;		/**< default radius in which the mission is accepted as reached in meters */
-			float loiter_radius;			/**< loiter radius in meters, 0 for a VTOL to hover, negative for counter-clockwise */
+			union {
+				float loiter_radius;		/**< loiter radius in meters, 0 for a VTOL to hover, negative for counter-clockwise */
+				float fence_action;		/**< geofence action */
+			};
 			float yaw;				/**< in radians NED -PI..+PI, NAN means don't change yaw		*/
 			float ___lat_float;			/**< padding */
 			float ___lon_float;			/**< padding */
@@ -221,8 +224,9 @@ struct mission_fence_point_s {
 
 	uint16_t nav_cmd;				/**< navigation command (one of MAV_CMD_NAV_FENCE_*) */
 	uint8_t frame;					/**< MAV_FRAME */
+	uint8_t fence_action;				/**< geofence action */
 
-	uint8_t _padding0[5];				/**< padding struct size to alignment boundary  */
+	uint8_t _padding0[4];				/**< padding struct size to alignment boundary  */
 };
 
 /**

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -801,7 +801,6 @@ void Navigator::run()
 void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 {
 	if (have_geofence_position_data &&
-	    (_geofence.getGeofenceAction() != geofence_result_s::GF_ACTION_NONE) &&
 	    (hrt_elapsed_time(&_last_geofence_check) > GEOFENCE_CHECK_INTERVAL_US)) {
 
 		const position_controller_status_s &pos_ctrl_status = _position_controller_status_sub.get();
@@ -870,6 +869,7 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 
 		_geofence_result.timestamp = hrt_absolute_time();
 		_geofence_result.geofence_action = _geofence.getGeofenceAction();
+		_geofence_result.action_required = _geofence.isActionRequired();
 		_geofence_result.home_required = _geofence.isHomeRequired();
 
 		if (gf_violation_type.value) {

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -860,9 +860,11 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 		gf_violation_type.flags.max_altitude_exceeded = !_geofence.isBelowMaxAltitude(_global_pos.alt +
 				vertical_test_point_distance);
 
-		gf_violation_type.flags.fence_violation = !_geofence.isInsidePolygonOrCircle(fence_violation_test_point(0),
+		gf_violation_type.flags.fence_violation = !_geofence.isInsideFence(fence_violation_test_point(0),
 				fence_violation_test_point(1),
-				_global_pos.alt);
+				_global_pos.alt + vertical_test_point_distance);
+
+		gf_violation_type.flags.max_altitude_exceeded |= _geofence.isMaxAltitudeExceeded();
 
 		_last_geofence_check = hrt_absolute_time();
 		have_geofence_position_data = false;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -934,6 +934,8 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 
 			/* Reset the _geofence_violation_warning_sent field */
 			_geofence_violation_warning_sent = false;
+
+			_geofence.resetGeofenceAction();
 		}
 
 		_geofence_result_pub.publish(_geofence_result);


### PR DESCRIPTION
**Describe the problem solved by this pull request**
This PR added a feature for storing individual fence actions and the maximum altitude for each fence. 

**Describe your solution**
The Mavlink receiver parses `MAV_CMD_NAV_FENCE_* ` messages and additionally saves fence action from param3 and altitude from param7, and stores it into Dataman with a geofence structure. 

This solution removes the parameter `GF_MAX_VER_DIST`. Now all maximum altitudes are controlled from QGC point where maximum altitude is sent from QGC and needs to be in AMSL.

Not every fence breach is equally significant. This PR emphasizes the importance of detecting breaches with the highest severity. For example, the highest severity is flight termination. This change aims to simplify the code and enhance security. When two fences are close, and the program can't quickly identify which one is breached and where it will prioritize the action with the highest severity.

Fence action with a higher number has the highest severity: 
https://github.com/aviant-tech/PX4-Autopilot/pull/39/files#diff-9707810253d8c0a1028d7dad1b7d5186e1d9df4909b0b0bca80b51143dd1970cL2-R7

Param `GF_ACTION ` is also removed, action is expected to arrive from QGC. 

All other logic, how the vehicle will behave when action is triggered, for certain fence breached, is preserved. 

**Test data/coverage**
It is tested in SITL. 

**Additional context**
It needs to be paired with QGC changes https://github.com/aviant-tech/qgroundcontrol/pull/22
