### PR TITLE
Support redundant ESC outputs: CAN and PWM

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -97,7 +97,7 @@ param set-default VT_TRANS_MIN_TM 4
 param set-default VT_TYPE 2
 
 set MIXER babyshark
-set MIXER_AUX babyshark
+set MIXER_AUX pass
 
 # Mark outputs for the alternate rate
 # or D-Shot

--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -97,7 +97,7 @@ param set-default VT_TRANS_MIN_TM 4
 param set-default VT_TYPE 2
 
 set MIXER babyshark
-set MIXER_AUX pass
+set MIXER_AUX babyshark
 
 # Mark outputs for the alternate rate
 # or D-Shot

--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -150,8 +150,27 @@ then
 
 	if [ $OUTPUT_MODE = uavcan_esc ]
 	then
+		# Load the mixer to the original PWM output as well
+		if mixer load ${OUTPUT_DEV} ${MIXER_FILE}
+		then
+			echo "INFO  [init] Mixer: ${MIXER_FILE} on ${OUTPUT_DEV}"
+
+		else
+			echo "ERROR  [init] Failed loading mixer: ${MIXER_FILE}"
+			tune_control play -t 18 # tune 18 = PROG_PX4IO_ERR
+		fi
+		# Set the pwm rate
+		if [ $PWM_MAIN_RATE != none ]
+		then
+			# Set PWM output frequency.
+			if ! param compare SYS_CTRL_ALLOC 1
+			then
+				pwm rate -c ${PWM_OUT} -r ${PWM_MAIN_RATE}
+			fi
+		fi
+
+		# Then we allow the mixer to be loaded to UAVCAN as well
 		set OUTPUT_DEV /dev/uavcan/esc
-		set OUTPUT_AUX_DEV /dev/pwm_output0
 	fi
 
 	if mixer load ${OUTPUT_DEV} ${MIXER_FILE}

--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -151,6 +151,7 @@ then
 	if [ $OUTPUT_MODE = uavcan_esc ]
 	then
 		set OUTPUT_DEV /dev/uavcan/esc
+		set OUTPUT_AUX_DEV /dev/pwm_output0
 	fi
 
 	if mixer load ${OUTPUT_DEV} ${MIXER_FILE}


### PR DESCRIPTION
We want to use the new KDE-UAS85UVC over DroneCAN, with PWM signals as redundancy. 

In order to achieve this, we need the CubeOrange to output DroneCAN messages and PWM signals on the MAIN output pins at the same time. There is no built-in parameter or mechanism to do this. Instead, we map the mixer to both the logical MAIN and logial AUX output. 

If the FC is set to output MAIN over DroneCAN instead of the physical MAIN pins, this PR makes the FC remap the logical AUX to the physical MAIN pins. This means we get both DroneCAN and PWM outputs at the same time.

This has been tested on a CubeOrange and KDE-UAS85UVC ESC. A scope has been used to verify pwm outputs on all pins.