### PR TITLE
Deploy parachute if global position lost above required distance from the ground

### DIFF
--- a/msg/failure_detector_status.msg
+++ b/msg/failure_detector_status.msg
@@ -10,5 +10,6 @@ bool fd_high_wind
 bool fd_battery
 bool fd_imbalanced_prop
 bool fd_mpc_vz
+bool fd_nav_state
 
 float32 imbalanced_prop_metric      # Metric of the imbalanced propeller check (low-passed)

--- a/msg/vehicle_control_mode.msg
+++ b/msg/vehicle_control_mode.msg
@@ -13,4 +13,3 @@ bool flag_control_velocity_enabled		# true if horizontal velocity (implies direc
 bool flag_control_position_enabled		# true if position is controlled
 bool flag_control_altitude_enabled		# true if altitude is controlled
 bool flag_control_climb_rate_enabled		# true if climb rate is controlled
-bool flag_control_termination_enabled		# true if flighttermination is enabled

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2883,7 +2883,7 @@ Commander::run()
 						events::send(events::ID("commander_fd_lockdown"), {events::Log::Emergency, events::LogInternal::Warning},
 							     "Critical failure detected: lockdown");
 
-					} else if (_failure_detector.getTerminationAllowed() &&
+					} else if (isTerminationAllowed() &&
 						   !_status_flags.circuit_breaker_flight_termination_disabled &&
 						   !_flight_termination_triggered && !_lockdown_triggered) {
 
@@ -4500,6 +4500,22 @@ void Commander::checkWindAndWarn()
 			_last_wind_warning = hrt_absolute_time();
 		}
 	}
+}
+
+bool Commander::isTerminationAllowed()
+{
+	vehicle_local_position_s local_position;
+	_local_position_sub.copy(&local_position);
+
+	bool termination_allowed = true;
+
+	// If the measurement is valid and under the distance threshold, flight termination is not allowed, otherwise it is.
+	if (local_position.dist_bottom_valid && (local_position.dist_bottom < _param_fd_min_dist_trm.get())) {
+		termination_allowed = false;
+
+	}
+
+	return termination_allowed;
 }
 
 int Commander::print_usage(const char *reason)

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2988,7 +2988,8 @@ Commander::run()
 						       static_cast<offboard_loss_rc_actions_t>(_param_com_obl_rc_act.get()),
 						       static_cast<position_nav_loss_actions_t>(_param_com_posctl_navl.get()),
 						       _param_com_rcl_act_t.get(),
-						       _param_com_rcl_except.get());
+						       _param_com_rcl_except.get(),
+						       isTerminationAllowed());
 
 		if (nav_state_changed) {
 			_status.nav_state_timestamp = hrt_absolute_time();

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2863,7 +2863,7 @@ Commander::run()
 				}
 
 				if (fd_status_flags.roll || fd_status_flags.pitch || fd_status_flags.alt || fd_status_flags.ext
-				    || fd_status_flags.mpc_vz) {
+				    || fd_status_flags.mpc_vz || fd_status_flags.nav_state) {
 					const bool is_right_after_takeoff = hrt_elapsed_time(&_status.takeoff_time) < (1_s * _param_com_lkdown_tko.get());
 
 					if (is_right_after_takeoff && !_lockdown_triggered) {
@@ -3467,9 +3467,8 @@ Commander::update_control_mode()
 		break;
 
 	case vehicle_status_s::NAVIGATION_STATE_TERMINATION:
-		/* disable all controllers on termination */
-		_vehicle_control_mode.flag_control_termination_enabled = true;
-		break;
+		/* Exit the function. We are handling flight termination inside commander. */
+		return;
 
 	case vehicle_status_s::NAVIGATION_STATE_OFFBOARD:
 		_vehicle_control_mode.flag_control_offboard_enabled = true;

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2987,6 +2987,7 @@ Commander::run()
 						       static_cast<quadchute_actions_t>(_param_com_qc_act.get()),
 						       static_cast<offboard_loss_rc_actions_t>(_param_com_obl_rc_act.get()),
 						       static_cast<position_nav_loss_actions_t>(_param_com_posctl_navl.get()),
+						       static_cast<global_position_loss_response_t>(_param_com_glb_pos_loss.get()),
 						       _param_com_rcl_act_t.get(),
 						       _param_com_rcl_except.get(),
 						       isTerminationAllowed());

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -184,6 +184,8 @@ private:
 
 	void checkWindAndWarn();
 
+	bool isTerminationAllowed();
+
 	DEFINE_PARAMETERS(
 
 		(ParamInt<px4::params::NAV_DLL_ACT>) _param_nav_dll_act,
@@ -276,7 +278,9 @@ private:
 		(ParamFloat<px4::params::CP_DIST>) _param_cp_dist,
 
 		(ParamFloat<px4::params::BAT_LOW_THR>) _param_bat_low_thr,
-		(ParamFloat<px4::params::BAT_CRIT_THR>) _param_bat_crit_thr
+		(ParamFloat<px4::params::BAT_CRIT_THR>) _param_bat_crit_thr,
+
+		(ParamFloat<px4::params::FD_MIN_DIST_TRM>) _param_fd_min_dist_trm
 	)
 
 	enum class PrearmedMode {

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -207,6 +207,7 @@ private:
 		(ParamFloat<px4::params::COM_POS_FS_EPV>) _param_com_pos_fs_epv, 	/*Not realy used for now*/
 		(ParamFloat<px4::params::COM_VEL_FS_EVH>) _param_com_vel_fs_evh,
 		(ParamInt<px4::params::COM_POSCTL_NAVL>) _param_com_posctl_navl,	/* failsafe response to loss of navigation accuracy */
+		(ParamInt<px4::params::COM_GLB_POS_LOSS>) _param_com_glb_pos_loss,	/* failsafe response to global position loss */
 
 		(ParamInt<px4::params::COM_POS_FS_DELAY>) _param_com_pos_fs_delay,
 

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -739,6 +739,18 @@ PARAM_DEFINE_INT32(COM_ARM_MIS_REQ, 0);
 PARAM_DEFINE_INT32(COM_POSCTL_NAVL, 0);
 
 /**
+ * Global postion loss response.
+ *
+ * This sets the response that will be used if global postion is loss
+ *
+ * @value 0 Terminate. Response for flight termination in case of global position loss.
+ * @value 1 Descend. Response to make vehicle descend in case of global position loss.
+ *
+ * @group Commander
+ */
+PARAM_DEFINE_INT32(COM_GLB_POS_LOSS, 0);
+
+/**
  * Require arm authorization to arm
  *
  * By default off. The default allows to arm the vehicle without a arm authorization.

--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -80,6 +80,8 @@ bool FailureDetector::update(const vehicle_status_s &vehicle_status, const vehic
 		_status.flags.mpc_vz = false;
 	}
 
+	_status.flags.nav_state = (vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_TERMINATION);
+
 	return _status.value != status_prev.value;
 }
 

--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -80,23 +80,7 @@ bool FailureDetector::update(const vehicle_status_s &vehicle_status, const vehic
 		_status.flags.mpc_vz = false;
 	}
 
-	updateTerminationAllowedStatus();
-
 	return _status.value != status_prev.value;
-}
-
-void FailureDetector::updateTerminationAllowedStatus()
-{
-	vehicle_local_position_s local_position;
-	_vehicle_local_position_sub.copy(&local_position);
-
-	// If the measurement is valid and under the distance threshold, flight termination is not allowed, otherwise it is.
-	if (local_position.dist_bottom_valid && (local_position.dist_bottom < _param_fd_min_dist_trm_p.get())) {
-		_termination_allowed = false;
-
-	} else {
-		_termination_allowed = true;
-	}
 }
 
 void FailureDetector::updateAttitudeStatus()

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -85,13 +85,11 @@ public:
 	FailureDetector(ModuleParams *parent);
 
 	bool update(const vehicle_status_s &vehicle_status, const vehicle_control_mode_s &vehicle_control_mode);
-	bool getTerminationAllowed() {return _termination_allowed; };
 	const failure_detector_status_u &getStatus() const { return _status; }
 	const decltype(failure_detector_status_u::flags) &getStatusFlags() const { return _status.flags; }
 	float getImbalancedPropMetric() const { return _imbalanced_prop_lpf.getState(); }
 
 private:
-	void updateTerminationAllowedStatus();
 	void updateAttitudeStatus();
 	void updateExternalAtsStatus();
 	void updateEscsStatus(const vehicle_status_s &vehicle_status);
@@ -106,7 +104,6 @@ private:
 	systemlib::Hysteresis _esc_failure_hysteresis{false};
 	systemlib::Hysteresis _mpc_vz_failure_hysteresis{false};
 
-	bool _termination_allowed{false}; ///< Flag indicating if preconditions for flight termination are satisfied
 	static constexpr float _imbalanced_prop_lpf_time_constant{5.f};
 	AlphaFilter<float> _imbalanced_prop_lpf{};
 	uint32_t _selected_accel_device_id{0};
@@ -121,7 +118,6 @@ private:
 	uORB::Subscription _vehicle_local_position_setpoint_sub{ORB_ID(vehicle_local_position_setpoint)};
 
 	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::FD_MIN_DIST_TRM>) _param_fd_min_dist_trm_p,
 		(ParamInt<px4::params::FD_FAIL_P>) _param_fd_fail_p,
 		(ParamInt<px4::params::FD_FAIL_R>) _param_fd_fail_r,
 		(ParamFloat<px4::params::FD_FAIL_R_TTRI>) _param_fd_fail_r_ttri,

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -73,6 +73,7 @@ union failure_detector_status_u {
 		uint16_t battery : 1;
 		uint16_t imbalanced_prop : 1;
 		uint16_t mpc_vz : 1;
+		uint16_t nav_state : 1;
 	} flags;
 	uint16_t value {0};
 };

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -298,6 +298,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		   const quadchute_actions_t quadchute_act,
 		   const offboard_loss_rc_actions_t offb_loss_rc_act,
 		   const position_nav_loss_actions_t posctl_nav_loss_act,
+		   const global_position_loss_response_t param_com_glb_pos_loss_resp,
 		   const float param_com_rcl_act_t, const int param_com_rcl_except,
 		   const bool is_termination_allowed)
 {
@@ -370,7 +371,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 
 			} else if (check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags,
 							       rc_fallback_allowed, status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING,
-							       is_termination_allowed)) {
+							       param_com_glb_pos_loss_resp, is_termination_allowed)) {
 				// nothing to do - everything done in check_invalid_pos_nav_state
 
 			} else if (status_flags.vtol_transition_failure) {
@@ -390,7 +391,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		 * - on data and RC link loss */
 
 		if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true,
-				is_termination_allowed)) {
+				param_com_glb_pos_loss_resp, is_termination_allowed)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 		} else if (status.engine_failure) {
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
@@ -447,7 +448,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true,
-				is_termination_allowed)) {
+				param_com_glb_pos_loss_resp, is_termination_allowed)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 
 		} else if (status_flags.vtol_transition_failure) {
@@ -489,7 +490,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true,
-				is_termination_allowed)) {
+				param_com_glb_pos_loss_resp, is_termination_allowed)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 		} else {
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
@@ -505,7 +506,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true,
-				is_termination_allowed)) {
+				param_com_glb_pos_loss_resp, is_termination_allowed)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 
 		} else {
@@ -524,7 +525,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 			internal_state.main_state = commander_state_s::MAIN_STATE_POSCTL;
 
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true,
-				is_termination_allowed)) {
+				param_com_glb_pos_loss_resp, is_termination_allowed)) {
 			// failsafe: necessary position estimate lost; switching is done in check_invalid_pos_nav_state
 
 			// Orbit can only be started via vehicle_command (mavlink). Consequently, recovery from failsafe into orbit
@@ -567,7 +568,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false,
-				is_termination_allowed)) {
+				param_com_glb_pos_loss_resp, is_termination_allowed)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 
 		} else if (status_flags.vtol_transition_failure) {
@@ -610,7 +611,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false,
-				is_termination_allowed)) {
+				param_com_glb_pos_loss_resp, is_termination_allowed)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 
 		} else {
@@ -627,7 +628,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false,
-				is_termination_allowed)) {
+				param_com_glb_pos_loss_resp, is_termination_allowed)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 
 		} else {
@@ -678,6 +679,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 
 bool check_invalid_pos_nav_state(vehicle_status_s &status, bool old_failsafe, orb_advert_t *mavlink_log_pub,
 				 const vehicle_status_flags_s &status_flags, const bool use_rc, const bool using_global_pos,
+				 const global_position_loss_response_t param_com_glb_pos_loss_resp,
 				 const bool is_termination_allowed)
 {
 	bool fallback_required = false;
@@ -710,12 +712,26 @@ bool check_invalid_pos_nav_state(vehicle_status_s &status, bool old_failsafe, or
 			if (status_flags.local_position_valid) {
 				status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
 
-			} else if (status_flags.local_altitude_valid && !is_termination_allowed) {
-				// If it is allowed, priority is on flight termination since the parachute deploying is preferred
-				status.nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
+			} else if (param_com_glb_pos_loss_resp == global_position_loss_response_t::DESCEND) {
 
-			} else {
-				status.nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
+				if (status_flags.local_altitude_valid) {
+					status.nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
+
+				} else {
+					// Altitude is not valid, it is better to terminate the flight.
+					status.nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
+				}
+
+			} else if (param_com_glb_pos_loss_resp == global_position_loss_response_t::TERMINATE) {
+
+				if (!is_termination_allowed && status_flags.local_altitude_valid) {
+					// Flight termination is not allowed. If altitude is valid try to descend.
+					status.nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
+
+				} else {
+					// Altitude is not valid, terminate the flight anyway.
+					status.nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
+				}
 			}
 		}
 

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -298,7 +298,8 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		   const quadchute_actions_t quadchute_act,
 		   const offboard_loss_rc_actions_t offb_loss_rc_act,
 		   const position_nav_loss_actions_t posctl_nav_loss_act,
-		   const float param_com_rcl_act_t, const int param_com_rcl_except)
+		   const float param_com_rcl_act_t, const int param_com_rcl_except,
+		   const bool is_termination_allowed)
 {
 	const navigation_state_t nav_state_old = status.nav_state;
 
@@ -368,7 +369,8 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 				 * For fixedwing, a global position is needed. */
 
 			} else if (check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags,
-							       rc_fallback_allowed, status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING)) {
+							       rc_fallback_allowed, status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING,
+							       is_termination_allowed)) {
 				// nothing to do - everything done in check_invalid_pos_nav_state
 
 			} else if (status_flags.vtol_transition_failure) {
@@ -387,7 +389,8 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		 * - if we have vtol transition failure
 		 * - on data and RC link loss */
 
-		if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
+		if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true,
+				is_termination_allowed)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 		} else if (status.engine_failure) {
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
@@ -443,7 +446,8 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		if (status.engine_failure) {
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
-		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
+		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true,
+				is_termination_allowed)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 
 		} else if (status_flags.vtol_transition_failure) {
@@ -484,7 +488,8 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		if (status.engine_failure) {
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
-		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
+		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true,
+				is_termination_allowed)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 		} else {
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
@@ -499,7 +504,8 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		if (status.engine_failure) {
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
-		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
+		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true,
+				is_termination_allowed)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 
 		} else {
@@ -517,7 +523,8 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 			// is not possible and therefore the internal_state needs to be adjusted.
 			internal_state.main_state = commander_state_s::MAIN_STATE_POSCTL;
 
-		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
+		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true,
+				is_termination_allowed)) {
 			// failsafe: necessary position estimate lost; switching is done in check_invalid_pos_nav_state
 
 			// Orbit can only be started via vehicle_command (mavlink). Consequently, recovery from failsafe into orbit
@@ -559,7 +566,8 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		if (status.engine_failure) {
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
-		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false)) {
+		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false,
+				is_termination_allowed)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 
 		} else if (status_flags.vtol_transition_failure) {
@@ -601,7 +609,8 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		if (status.engine_failure) {
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
-		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false)) {
+		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false,
+				is_termination_allowed)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 
 		} else {
@@ -617,7 +626,8 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		if (status.engine_failure) {
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
-		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false)) {
+		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false,
+				is_termination_allowed)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 
 		} else {
@@ -667,7 +677,8 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 }
 
 bool check_invalid_pos_nav_state(vehicle_status_s &status, bool old_failsafe, orb_advert_t *mavlink_log_pub,
-				 const vehicle_status_flags_s &status_flags, const bool use_rc, const bool using_global_pos)
+				 const vehicle_status_flags_s &status_flags, const bool use_rc, const bool using_global_pos,
+				 const bool is_termination_allowed)
 {
 	bool fallback_required = false;
 
@@ -699,8 +710,8 @@ bool check_invalid_pos_nav_state(vehicle_status_s &status, bool old_failsafe, or
 			if (status_flags.local_position_valid) {
 				status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
 
-			} else if (status_flags.local_altitude_valid) {
-
+			} else if (status_flags.local_altitude_valid && !is_termination_allowed) {
+				// If it is allowed, priority is on flight termination since the parachute deploying is preferred
 				status.nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
 
 			} else {

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -120,14 +120,16 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		   const quadchute_actions_t quadchute_act,
 		   const offboard_loss_rc_actions_t offb_loss_rc_act,
 		   const position_nav_loss_actions_t posctl_nav_loss_act,
-		   const float param_com_rcl_act_t, const int param_com_rcl_except);
+		   const float param_com_rcl_act_t, const int param_com_rcl_except,
+		   const bool is_termination_allowed);
 
 /*
  * Checks the validty of position data against the requirements of the current navigation
  * mode and switches mode if position data required is not available.
  */
 bool check_invalid_pos_nav_state(vehicle_status_s &status, bool old_failsafe, orb_advert_t *mavlink_log_pub,
-				 const vehicle_status_flags_s &status_flags, const bool use_rc, const bool using_global_pos);
+				 const vehicle_status_flags_s &status_flags, const bool use_rc, const bool using_global_pos,
+				 const bool is_termination_allowed);
 
 
 // COM_LOW_BAT_ACT parameter values

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -100,6 +100,11 @@ enum class position_nav_loss_actions_t {
 	LAND_TERMINATE = 1,	// Land/Terminate.  Assume no use of remote control after fallback. Switch to Land mode if a height estimate is available, else switch to TERMINATION.
 };
 
+enum class global_position_loss_response_t {
+	TERMINATE = 0,	// Response for flight termination in case of global position loss.
+	DESCEND = 1	// Response to make vehicle descend in case of global position loss.
+};
+
 extern const char *const arming_state_names[];
 extern const char *const nav_state_names[];
 
@@ -120,6 +125,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		   const quadchute_actions_t quadchute_act,
 		   const offboard_loss_rc_actions_t offb_loss_rc_act,
 		   const position_nav_loss_actions_t posctl_nav_loss_act,
+		   const global_position_loss_response_t param_com_glb_pos_loss,
 		   const float param_com_rcl_act_t, const int param_com_rcl_except,
 		   const bool is_termination_allowed);
 
@@ -129,6 +135,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
  */
 bool check_invalid_pos_nav_state(vehicle_status_s &status, bool old_failsafe, orb_advert_t *mavlink_log_pub,
 				 const vehicle_status_flags_s &status_flags, const bool use_rc, const bool using_global_pos,
+				 const global_position_loss_response_t param_com_glb_pos_loss,
 				 const bool is_termination_allowed);
 
 

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -283,13 +283,6 @@ MulticopterRateControl::Run()
 
 			updateActuatorControlsStatus(actuators, dt);
 
-		} else if (_v_control_mode.flag_control_termination_enabled) {
-			if (!_vehicle_status.is_vtol) {
-				// publish actuator controls
-				actuator_controls_s actuators{};
-				actuators.timestamp = hrt_absolute_time();
-				_actuators_0_pub.publish(actuators);
-			}
 		}
 	}
 

--- a/test/mavsdk_tests/test_multicopter_failsafe.cpp
+++ b/test/mavsdk_tests/test_multicopter_failsafe.cpp
@@ -33,7 +33,7 @@
 
 #include "autopilot_tester.h"
 
-
+#if 0 // disabled multicopter test for GPS lost.
 TEST_CASE("Land on GPS lost during mission (baro height mode)", "[multicopter]")
 {
 	AutopilotTester tester;
@@ -83,7 +83,6 @@ TEST_CASE("Continue on mag lost during mission", "[multicopter]")
 	tester.wait_until_disarmed(until_disarmed_timeout);
 }
 
-#if 0
 // This test is disabled for now because the estimator sometimes diverges on
 // right after landing which then prevents auto-disarm.
 TEST_CASE("Continue on mag stuck during mission", "[multicopter][vtol]")


### PR DESCRIPTION
**Describe the problem solved by this pull request**
Solution for the requirement to deploy a parachute if the vehicle is at an allowed distance from the ground rather than go into descent mode. 

**Describe your solution**
1)  The function to get information if termination is allowed is moved from the **failure detector** to the **commander**

2) Passing information about whether termination is allowed to **state machine helper** so logic can be preserved inside when determining in what state to go ( vehicle_status_s::NAVIGATION_STATE_DESCEND or vehicle_status_s::NAVIGATION_STATE_TERMINATION)

3) vehicle_status_s::NAVIGATION_STATE_TERMINATION is not handed inside the **commander** anymore but inside the **failure detector**. This means that the parachute will be deployed. The decision to go in this direction is made due to a similar work that was done upstream where is detected that  NAVIGATION_STATE_TERMINATION is handled in parallel logic so it is unified similarly. 

Additionally, before this changes vehicle could enter inside NAVIGATION_STATE_TERMINATION and the parachute would not be deployed. Now it will be deployed if the vehicle is above the required distance from the ground. 