### PR TITLE
Gps blend timestamp

### DIFF
--- a/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
@@ -494,17 +494,18 @@ sensor_gps_s GpsBlending::gps_blend_states(float blend_weights[GPS_MAX_RECEIVERS
 	}
 
 	// Blend UTC timestamp from all receivers that are publishing a valid time_us value
-	float utc_weight_sum = 0.0f;
+	double utc_weight_sum = 0.0;
+	double utc_time_sum = 0.0;
 
 	for (uint8_t i = 0; i < GPS_MAX_RECEIVERS_BLEND; i++) {
 		if (_gps_state[i].time_utc_usec > 0) {
-			gps_blended_state.time_utc_usec += (uint64_t)((double)_gps_state[i].time_utc_usec * (double)blend_weights[i]);
-			utc_weight_sum += blend_weights[i];
+			utc_time_sum += (double)_gps_state[i].time_utc_usec * (double)blend_weights[i];
+			utc_weight_sum += (double)blend_weights[i];
 		}
 	}
 
-	if (utc_weight_sum > 0.0f) {
-		gps_blended_state.time_utc_usec /= utc_weight_sum;
+	if (utc_weight_sum > 0.0) {
+		gps_blended_state.time_utc_usec = (uint64_t)(utc_time_sum / utc_weight_sum);
 	}
 
 	return gps_blended_state;

--- a/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
@@ -493,6 +493,20 @@ sensor_gps_s GpsBlending::gps_blend_states(float blend_weights[GPS_MAX_RECEIVERS
 		gps_blended_state.heading_accuracy = _gps_state[gps_best_yaw_index].heading_accuracy;
 	}
 
+	// Blend UTC timestamp from all receivers that are publishing a valid time_us value
+	float utc_weight_sum = 0.0f;
+
+	for (uint8_t i = 0; i < GPS_MAX_RECEIVERS_BLEND; i++) {
+		if (_gps_state[i].time_utc_usec > 0) {
+			gps_blended_state.time_utc_usec += (uint64_t)((double)_gps_state[i].time_utc_usec * (double)blend_weights[i]);
+			utc_weight_sum += blend_weights[i];
+		}
+	}
+
+	if (utc_weight_sum > 0.0f) {
+		gps_blended_state.time_utc_usec /= utc_weight_sum;
+	}
+
 	return gps_blended_state;
 }
 

--- a/src/modules/sensors/vehicle_gps_position/gps_blending_test.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending_test.cpp
@@ -275,3 +275,27 @@ TEST_F(GpsBlendingTest, dualReceiverFailover)
 	EXPECT_EQ(gps_blending.getSelectedGps(), 0);
 	EXPECT_TRUE(gps_blending.isNewOutputDataAvailable());
 }
+
+TEST_F(GpsBlendingTest, dualReceiverUtcTime)
+{
+	GpsBlending gps_blending;
+	// WHEN: only the secondary receiver has a valid time
+	sensor_gps_s gps_data0 = getDefaultGpsData();
+	sensor_gps_s gps_data1 = getDefaultGpsData();
+	gps_data_1.time_utc_usec = 1700000000000000ULL;
+	gps_blending.setBlendingUseHPosAccuracy(true);
+	gps_blending.update(_time_now_us);
+	// THEN: GPS 1 time should be used, since only GPS 1 has a valid time
+	EXPECT_EQ(gps_blending.getOutputGpsData().time_utc_usec, gps_data1.time_utc_usec);
+
+	// WHEN: both receivers have a valid time
+	gps_blending = GpsBlending();
+	sensor_gps_s gps_data0 = getDefaultGpsData();
+	sensor_gps_s gps_data1 = getDefaultGpsData();
+	gps_data_0.time_utc_usec = 1700000000001000ULL;
+	gps_data_1.time_utc_usec = 1700000000000000ULL;
+	gps_blending.setBlendingUseHPosAccuracy(true);
+	gps_blending.update(_time_now_us);
+	// THEN: The average of the two times should be used
+	EXPECT_EQ(gps_blending.getOutputGpsData().time_utc_usec, 1700000000000500ULL);
+}

--- a/src/modules/sensors/vehicle_gps_position/gps_blending_test.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending_test.cpp
@@ -282,7 +282,9 @@ TEST_F(GpsBlendingTest, dualReceiverUtcTime)
 	// WHEN: only the secondary receiver has a valid time
 	sensor_gps_s gps_data0 = getDefaultGpsData();
 	sensor_gps_s gps_data1 = getDefaultGpsData();
-	gps_data_1.time_utc_usec = 1700000000000000ULL;
+	gps_data1.time_utc_usec = 1700000000000000ULL;
+	gps_blending.setGpsData(gps_data0, 0);
+	gps_blending.setGpsData(gps_data1, 1);
 	gps_blending.setBlendingUseHPosAccuracy(true);
 	gps_blending.update(_time_now_us);
 	// THEN: GPS 1 time should be used, since only GPS 1 has a valid time
@@ -290,10 +292,9 @@ TEST_F(GpsBlendingTest, dualReceiverUtcTime)
 
 	// WHEN: both receivers have a valid time
 	gps_blending = GpsBlending();
-	sensor_gps_s gps_data0 = getDefaultGpsData();
-	sensor_gps_s gps_data1 = getDefaultGpsData();
-	gps_data_0.time_utc_usec = 1700000000001000ULL;
-	gps_data_1.time_utc_usec = 1700000000000000ULL;
+	gps_data0.time_utc_usec = 1700000000001000ULL;
+	gps_blending.setGpsData(gps_data0, 0);
+	gps_blending.setGpsData(gps_data1, 1);
 	gps_blending.setBlendingUseHPosAccuracy(true);
 	gps_blending.update(_time_now_us);
 	// THEN: The average of the two times should be used


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
When GPS blending is enabled, `vehicle_gps_position/time_utc_usec` is always 0 even when the GPS sensors have a valid UTC time.

**Describe your solution**
Blend UTC timestamp from all receivers that are publishing a valid time_us value

**Describe possible alternatives**
Instead of blending, one could simply pick the first GPS with a valid timestamp. However, since the system timestamps are blended, I think it is suitable to blend UTC time as well.

**Test data / coverage**
Added unit test for GPS UTC time blending.

**Additional context**

Pls squash-merge :pleading_face: 