### PR TITLE
uavcan: bugfix, publish correct deviceid for multiple uavcan gnss

### DIFF
--- a/src/drivers/uavcan/module.yaml
+++ b/src/drivers/uavcan/module.yaml
@@ -7,6 +7,8 @@ actuator_output:
       function: 'enable'
     - param: 'UAVCAN_BITRATE'
       label: 'Bitrate'
+    - param: 'UAVCAN_GPS1_ID'
+      label: 'GPS1 UAVCAN ID'
   output_groups:
     - param_prefix: UAVCAN_EC
       group_label: 'ESCs'

--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -325,7 +325,14 @@ void UavcanGnssBridge::process_fixx(const uavcan::ReceivedDataStructure<FixType>
 				    const float heading_accuracy)
 {
 	sensor_gps_s report{};
-	report.device_id = get_device_id();
+
+	device::Device::DeviceId device_id;
+	device_id.devid_s.bus_type = device::Device::DeviceBusType_UAVCAN;
+	device_id.devid_s.bus = msg.getIfaceIndex();
+	device_id.devid_s.devtype = DRV_GPS_DEVTYPE_UAVCAN;
+	device_id.devid_s.address =  msg.getSrcNodeID().get();
+
+	report.device_id = device_id.devid;
 
 	/*
 	 * FIXME HACK

--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -121,6 +121,16 @@ UavcanGnssBridge::init()
 		_moving_baseline_data_pub_perf = perf_alloc(PC_INTERVAL, "uavcan: gnss: moving baseline data rtcm stream pub");
 	}
 
+	// If GPS1_ID is set, pre-allocate a channel by sending a blank report. This ensures that it becomes the first instance.
+	int32_t uavcan_gps1_id = 0;
+	param_get(param_find("UAVCAN_GPS1_ID"), &uavcan_gps1_id);
+
+	if (uavcan_gps1_id > 0) {
+		PX4_INFO("Allocating UAVCAN node %ld as GPS1 because of UAVCAN_GPS1_ID param", uavcan_gps1_id);
+		sensor_gps_s report{};
+		publish(uavcan_gps1_id, &report);
+	}
+
 	return res;
 }
 

--- a/src/drivers/uavcan/uavcan_params.c
+++ b/src/drivers/uavcan/uavcan_params.c
@@ -385,3 +385,15 @@ PARAM_DEFINE_INT32(UAVCAN_SUB_BTN, 0);
  * @group UAVCAN
  */
 PARAM_DEFINE_INT32(UAVCAN_LOG_LEVEL, 1);
+
+/**
+ * UAVCAN ID to use as GPS1
+ *
+ * If > 0, UAVCAN GNSS bridge will allocate this UAVCAN ID as the first GPS instance.
+ *
+ * @min 0
+ * @max 127
+ * @reboot_required true
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(UAVCAN_GPS1_ID, 0);


### PR DESCRIPTION
### Problem solved
When using multiple DroneCAN GNSS sensors, they all get the same device id, as the id is stored in a variable shared by all sensor_gps channels.

This has already caused us some confusion, such as here during analysis of this log: https://aviant.atlassian.net/wiki/spaces/TECHNICAL/pages/693698594

### Solution
Use the source node id from the message instead of the shared variable.

### Context
See that GPSes got the same device id earlier, but now they get different IDs

Before, same IDs:
![before, same ID](https://github.com/aviant-tech/PX4-Autopilot/assets/28607452/9e72cb0d-eaaf-4dc1-bcb1-cd534df73985)
After, different IDs:
![after, different IDs](https://github.com/aviant-tech/PX4-Autopilot/assets/28607452/547b6e0f-b4cf-44dd-9d51-57d0b6172291)

I am working on getting this, bundled with a few more fixes upstream for 1.15: https://github.com/PX4/PX4-Autopilot/pull/22880
