### PR TITLE
bugfix: properly initialize gnss deviceid

### DIFF
--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -337,6 +337,7 @@ void UavcanGnssBridge::process_fixx(const uavcan::ReceivedDataStructure<FixType>
 	sensor_gps_s report{};
 
 	device::Device::DeviceId device_id;
+	device_id.devid = 0;
 	device_id.devid_s.bus_type = device::Device::DeviceBusType_UAVCAN;
 	device_id.devid_s.bus = msg.getIfaceIndex();
 	device_id.devid_s.devtype = DRV_GPS_DEVTYPE_UAVCAN;


### PR DESCRIPTION
The 8 most significant bits of the device_id.devid is not used by the devid_s struct. Since the bits were previously not zero-initialized, the most significant bits of the deviceid would seemingly randomly change.

This is fixed by properly initializing the variable.