### PR TITLE
workflow: actions/upload_artifact from v2 to v4

### DIFF
--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -69,7 +69,7 @@ jobs:
       run: ccache -s
 
     - name: Upload px4 package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: px4_package_${{matrix.config}}
         path: |

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -104,14 +104,14 @@ jobs:
       run: gdb build/px4_sitl_default/bin/px4 px4.core -ex "thread apply all bt" -ex "quit"
     - name: Upload px4 coredump
       if: failure()
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v4
       with:
         name: coredump
         path: px4.core
 
     - name: Upload px4 binary
       if: failure()
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v4
       with:
         name: binary
         path: build/px4_sitl_default/bin/px4


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/092d1c0a-67d7-4208-8e72-9551acdcdb9d)

Should fix this on aviant/1.13 as well, but we can do that separately to avoid having to rebase and forcepush https://github.com/aviant-tech/PX4-Autopilot/pull/73