### PR TITLE
feat: prioritize thrust over yaw when saturated

### DIFF
--- a/src/lib/mixer/MultirotorMixer/MultirotorMixer.cpp
+++ b/src/lib/mixer/MultirotorMixer/MultirotorMixer.cpp
@@ -302,8 +302,9 @@ void MultirotorMixer::mix_yaw(float yaw, float *outputs)
 	}
 
 	// Change yaw acceleration to unsaturate the outputs if needed (do not change roll/pitch),
-	// and allow some yaw response at maximum thrust
-	minimize_saturation(_tmp_array, outputs, _saturation_status, 0.f, 1.15f);
+	// Currently, never prioritize thrust over yaw.
+	// (Max value can be set >1 to allow some yaw response at maximum thrust)
+	minimize_saturation(_tmp_array, outputs, _saturation_status, 0.f, 1.f);
 
 	for (unsigned i = 0; i < _rotor_count; i++) {
 		_tmp_array[i] = _rotors[i].thrust_scale;

--- a/src/lib/mixer/MultirotorMixer/MultirotorMixer.cpp
+++ b/src/lib/mixer/MultirotorMixer/MultirotorMixer.cpp
@@ -302,7 +302,7 @@ void MultirotorMixer::mix_yaw(float yaw, float *outputs)
 	}
 
 	// Change yaw acceleration to unsaturate the outputs if needed (do not change roll/pitch),
-	// Currently, never prioritize thrust over yaw.
+	// Currently, never prioritize yaw over thrust.
 	// (Max value can be set >1 to allow some yaw response at maximum thrust)
 	minimize_saturation(_tmp_array, outputs, _saturation_status, 0.f, 1.f);
 

--- a/src/lib/mixer/MultirotorMixer/mixer_multirotor.py
+++ b/src/lib/mixer/MultirotorMixer/mixer_multirotor.py
@@ -88,9 +88,8 @@ def mix_yaw(m_sp, u, P, u_min, u_max):
     u_p = u + P * m_sp_yaw_only
 
     # Change yaw acceleration to unsaturate the outputs if needed (do not change roll/pitch),
-    # and allow some yaw response at maximum thrust
     u_r_dot = P[:,2]
-    u_pp = minimize_sat(u_p, u_min, u_max+0.15, u_r_dot)
+    u_pp = minimize_sat(u_p, u_min, u_max, u_r_dot)
     u_T = P[:, 3]
     u_ppp = minimize_sat(u_pp, 0, u_max, u_T)
     # reduce thrust only

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturation.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturation.cpp
@@ -219,7 +219,8 @@ ControlAllocationSequentialDesaturation::mixYaw()
 	// Change yaw acceleration to unsaturate the outputs if needed (do not change roll/pitch),
 	// and allow some yaw response at maximum thrust
 	ActuatorVector max_prev = _actuator_max;
-	_actuator_max += (_actuator_max - _actuator_min) * 0.15f;
+	// Uncomment line below to allow some yaw response at maximum thrust
+	//_actuator_max += (_actuator_max - _actuator_min) * 0.15f;
 	desaturateActuators(_actuator_sp, yaw);
 	_actuator_max = max_prev;
 


### PR DESCRIPTION
Currently, the mixer (and control allocator) allows some yaw response even when a motor is completely saturated.

With the current value `1.15f`(mixer)/`0.15f`(control allocator), up to 13 % of available control authority. For our usecase, we prefer giving up yaw control instead of losing altitude when motors are saturated.

To accomplish this, we change the constant to `1.0f` in mixer and remove the additional `0.15` thrust range factor in control allocator.