### PR TITLE
control_allocator: increase max num motors to 12

### DIFF
--- a/msg/actuator_motors.msg
+++ b/msg/actuator_motors.msg
@@ -4,7 +4,7 @@ uint64 timestamp_sample	    # the timestamp the data this control response is ba
 
 uint16 reversible_flags     # bitset which motors are configured to be reversible
 
-uint8 NUM_CONTROLS = 8
-float32[8] control # range: [-1, 1], where 1 means maximum positive thrust,
-                   # -1 maximum negative (if not supported by the output, <0 maps to NaN),
-                   # and NaN maps to disarmed (stop the motors)
+uint8 NUM_CONTROLS = 12
+float32[12] control # range: [-1, 1], where 1 means maximum positive thrust,
+                    # -1 maximum negative (if not supported by the output, <0 maps to NaN),
+                    # and NaN maps to disarmed (stop the motors)

--- a/msg/actuator_test.msg
+++ b/msg/actuator_test.msg
@@ -7,7 +7,7 @@ uint8 ACTION_RELEASE_CONTROL = 0	# exit test mode for the given function
 uint8 ACTION_DO_CONTROL = 1			# enable actuator test mode
 
 uint8 FUNCTION_MOTOR1 = 101
-uint8 MAX_NUM_MOTORS  = 8
+uint8 MAX_NUM_MOTORS  = 12
 uint8 FUNCTION_SERVO1 = 201
 uint8 MAX_NUM_SERVOS  = 8
 

--- a/src/lib/mixer_module/output_functions.yaml
+++ b/src/lib/mixer_module/output_functions.yaml
@@ -9,7 +9,7 @@ functions:
 
     Motor:
       start: 101
-      count: 8
+      count: 12
     Servo:
       start: 201
       count: 8

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRotors.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRotors.hpp
@@ -60,7 +60,7 @@ public:
 		FixedUpwards, ///< axis is fixed, pointing upwards (negative Z)
 	};
 
-	static constexpr int NUM_ROTORS_MAX = 8;
+	static constexpr int NUM_ROTORS_MAX = 12;
 
 	struct RotorGeometry {
 		matrix::Vector3f position;

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -1,4 +1,4 @@
-__max_num_mc_motors: &max_num_mc_motors 8
+__max_num_mc_motors: &max_num_mc_motors 12
 __max_num_servos: &max_num_servos 8
 __max_num_tilts: &max_num_tilts 4
 
@@ -58,6 +58,10 @@ parameters:
                 5: Motor 6
                 6: Motor 7
                 7: Motor 8
+                8: Motor 9
+                9: Motor 10
+                10: Motor 11
+                11: Motor 12
             default: 0
         CA_R${i}_SLEW:
             description:
@@ -111,6 +115,10 @@ parameters:
                 6: '6'
                 7: '7'
                 8: '8'
+                9: '9'
+                10: '10'
+                11: '11'
+                12: '12'
             default: 0
         CA_ROTOR${i}_PX:
             description:


### PR DESCRIPTION
Needed to use the pusher on the octa setup.
Picker from upstream.
Tested on NX03 with https://github.com/aviant-tech/PX4-Autopilot/releases/tag/v1.13.2-1.13.6-beta4