### PR TITLE
feat: quadratic compensation of fixed-wing throttle

### DIFF
--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -340,9 +340,10 @@ void VehicleMagnetometer::UpdatePowerCompensation()
 		if (_armed && (_mag_comp_type == MagCompensationType::Throttle)) {
 			actuator_controls_s controls;
 
-			if (_actuator_controls_0_sub.update(&controls)) {
+			if (_actuator_controls_1_sub.update(&controls)) {
 				for (auto &cal : _calibration) {
-					cal.UpdatePower(controls.control[actuator_controls_s::INDEX_THROTTLE]);
+					const float throttle = controls.control[actuator_controls_s::INDEX_THROTTLE];
+					cal.UpdatePower(throttle * throttle);
 				}
 			}
 

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.hpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.hpp
@@ -110,7 +110,7 @@ private:
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
-	uORB::Subscription _actuator_controls_0_sub{ORB_ID(actuator_controls_0)};
+	uORB::Subscription _actuator_controls_1_sub{ORB_ID(actuator_controls_1)};
 	uORB::Subscription _battery_status_sub{ORB_ID(battery_status), 0};
 	uORB::Subscription _magnetometer_bias_estimate_sub{ORB_ID(magnetometer_bias_estimate)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};


### PR DESCRIPTION
Internal compass is only affected by the pusher. The magnetic interference depends on the current which is approximately the squared throttle.

- [ ] Test on the ground on NX01 to verify that mag estimate remains stable.
- [ ] Figure out which parameters/config we want.
- [ ] Test in the air on NX01.
- [ ] Test in the air on NT17.
- [ ] Prod approve NT17.
- [ ] Make some feedback loop to detect and update wrong params.