### PR TITLE
Add missing rc.sysinit file in the ROMFS

### DIFF
--- a/ROMFS/px4fmu_common/init.d/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/CMakeLists.txt
@@ -44,6 +44,7 @@ px4_add_romfs_files(
 	# TODO
 	rc.balloon_apps
 	rc.balloon_defaults
+	rc.sysinit
 )
 
 if(CONFIG_MODULES_AIRSHIP_ATT_CONTROL)

--- a/ROMFS/px4fmu_common/init.d/rc.sysinit
+++ b/ROMFS/px4fmu_common/init.d/rc.sysinit
@@ -1,0 +1,4 @@
+#!/bin/sh
+#
+# Standard system init script
+#


### PR DESCRIPTION
Cherry picked https://github.com/PX4/PX4-Autopilot/commit/d4d60a5181b83e51d63ee5af6befaf33d873df5c from upsteam, as this is an annoyance when using nsh. It is scheduled for inclusion in 1.16, but we want it in our 1.15 as well.

https://github.com/PX4/PX4-Autopilot/commit/d4d60a5181b83e51d63ee5af6befaf33d873df5c