### PR TITLE
Dynamic CA and octocopter

### DIFF
--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -8,6 +8,7 @@ float32 current_average_a	# Battery current average in amperes, -1 if unknown
 float32 discharged_mah		# Discharged amount in mAh, -1 if unknown
 float32 remaining			# From 1 to 0, -1 if unknown
 float32 scale				# Power scaling factor, >= 1, or -1 if unknown
+float32 dynamic_actuator	# From 0 to 1, how much of actuator output dynamic range to allow, -1 for failure to calculate
 float32 time_remaining_s	# predicted time in seconds remaining until battery is empty under previous averaged load, NAN if unknown
 float32 temperature			# temperature of the battery. NaN if unknown
 uint8 cell_count			# Number of cells, 0 if unknown

--- a/src/drivers/uavcan/uavcan_params.c
+++ b/src/drivers/uavcan/uavcan_params.c
@@ -411,3 +411,39 @@ PARAM_DEFINE_INT32(UAVCAN_LOG_LEVEL, 1);
  * @group UAVCAN
  */
 PARAM_DEFINE_INT32(UAVCAN_GPS1_ID, 0);
+
+/**
+ * Outputs with dynamic max limiting
+ *
+ * The selected outputs will reduce the max output
+ * based on UAVCAN_EC_DRNG and the dynamic allocator
+ * signal received from the battery module.
+ *
+ * @group UAVCAN
+ * @min 0
+ * @max 255
+ * @bit 0 Channel 1
+ * @bit 1 Channel 2
+ * @bit 2 Channel 3
+ * @bit 3 Channel 4
+ * @bit 4 Channel 5
+ * @bit 5 Channel 6
+ * @bit 6 Channel 7
+ * @bit 7 Channel 8
+ */
+PARAM_DEFINE_INT32(UAVCAN_EC_DCHNS, 0);
+
+/**
+ * Amount to reduce max limit, given a full battery
+ *
+ * The outputs given by UAVCAN_EC_DCHNS will have a reduction
+ * in output range (max-min) given by this scalar when the
+ * battery is full. The output will gradually be scaled up
+ * as the battery is drained.
+ *
+ * @group UAVCAN
+ * @min 0.0
+ * @max 1.0
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(UAVCAN_EC_DRNG, 0);

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -90,6 +90,12 @@ Battery::Battery(int index, ModuleParams *parent, const int sample_interval_us, 
 	snprintf(param_name, sizeof(param_name), "BAT%d_SOURCE", _index);
 	_param_handles.source = param_find(param_name);
 
+	snprintf(param_name, sizeof(param_name), "BAT%d_DYNACT", _index);
+	_param_handles.dynact = param_find(param_name);
+
+	snprintf(param_name, sizeof(param_name), "BAT%d_Q_MAXACT", _index);
+	_param_handles.q_maxact = param_find(param_name);
+
 	_param_handles.low_thr = param_find("BAT_LOW_THR");
 	_param_handles.crit_thr = param_find("BAT_CRIT_THR");
 	_param_handles.emergen_thr = param_find("BAT_EMERGEN_THR");
@@ -126,6 +132,7 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp)
 	sumDischarged(timestamp, _current_a);
 	estimateStateOfCharge(_voltage_filter_v.getState(), _current_filter_a.getState());
 	computeScale();
+	computeDynamicActuator();
 
 	if (_connected && _battery_initialized) {
 		_warning = determineWarning(_state_of_charge);
@@ -150,6 +157,7 @@ battery_status_s Battery::getBatteryStatus()
 	battery_status.discharged_mah = _discharged_mah;
 	battery_status.remaining = _state_of_charge;
 	battery_status.scale = _scale;
+	battery_status.dynamic_actuator = _dynamic_actuator;
 	battery_status.time_remaining_s = computeRemainingTime(_current_a);
 	battery_status.temperature = _temperature_c;
 	battery_status.cell_count = _params.n_cells;
@@ -273,6 +281,47 @@ void Battery::computeScale()
 	}
 }
 
+void Battery::computeDynamicActuator()
+{
+	// Check if the battery is full, based on voltage alone,
+	// and latch the status if it is.
+	if (!_battery_was_full) {
+		float min_voltage = _params.n_cells * _params.v_charged * 0.97f;  // Hard code 3% acceptance range
+		float max_voltage = _params.n_cells * _params.v_charged * 1.2f;   // Sanity check
+		float voltage = _voltage_filter_v.getState();
+
+		if (voltage < max_voltage && voltage > min_voltage) { _battery_was_full = true; }
+	}
+
+	switch (_params.dynact) {
+	case -1:  // Disabled - dynamic range always disabled
+		_dynamic_actuator = 0.f;
+		break;
+
+	case 0:  // Disabled - dynamic range always enabled
+		_dynamic_actuator = 1.f;
+		break;
+
+	case 1:  // Consumption based - require full battery
+		if (!_battery_was_full) {
+			_dynamic_actuator = -1.f;
+
+		} else {
+			_dynamic_actuator = gradual(_discharged_mah, 0.f, _params.q_maxact, 0.f, 1.f);
+		}
+
+		break;
+
+	case 2:  // Consumption based - do not require full battery
+		_dynamic_actuator = gradual(_discharged_mah, 0.f, _params.q_maxact, 0.f, 1.f);
+		break;
+
+	default:
+		// Set to error value if unknown mode
+		_dynamic_actuator = -1.f;
+	}
+}
+
 float Battery::computeRemainingTime(float current_a)
 {
 	float time_remaining_s = NAN;
@@ -313,6 +362,8 @@ void Battery::updateParams()
 	param_get(_param_handles.v_load_drop, &_params.v_load_drop);
 	param_get(_param_handles.r_internal, &_params.r_internal);
 	param_get(_param_handles.source, &_params.source);
+	param_get(_param_handles.dynact, &_params.dynact);
+	param_get(_param_handles.q_maxact, &_params.q_maxact);
 	param_get(_param_handles.low_thr, &_params.low_thr);
 	param_get(_param_handles.crit_thr, &_params.crit_thr);
 	param_get(_param_handles.emergen_thr, &_params.emergen_thr);

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -122,6 +122,8 @@ protected:
 		param_t emergen_thr;
 		param_t source;
 		param_t bat_avrg_current;
+		param_t dynact;
+		param_t q_maxact;
 	} _param_handles{};
 
 	struct {
@@ -136,6 +138,8 @@ protected:
 		float emergen_thr;
 		int32_t source;
 		float bat_avrg_current;
+		int32_t dynact;
+		float q_maxact;
 	} _params{};
 
 	const int _index;
@@ -148,6 +152,7 @@ private:
 	void estimateStateOfCharge(const float voltage_v, const float current_a);
 	uint8_t determineWarning(float state_of_charge);
 	void computeScale();
+	void computeDynamicActuator();
 	float computeRemainingTime(float current_a);
 
 	uORB::Subscription _actuator_controls_0_sub{ORB_ID(actuator_controls_0)};
@@ -170,6 +175,8 @@ private:
 	float _state_of_charge{-1.f}; // [0,1]
 	float _scale{1.f};
 	float _temperature_c{NAN};
+	float _dynamic_actuator{-1.f};
+	bool _battery_was_full{false};
 	uint8_t _warning{battery_status_s::BATTERY_WARNING_NONE};
 	hrt_abstime _last_timestamp{0};
 	bool _armed{false};

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -142,3 +142,36 @@ parameters:
             num_instances: *max_num_config_instances
             instance_start: 1
             default: [0, -1]
+
+        BAT${i}_Q_MAXACT:
+            description:
+                short: Battery ${i} consumption limit for scaling dynamic actuator output.
+                long: |
+                    Defines a battery consumption limit for battery ${i} in mAh, after which
+                    the full dynamic actuator limit will be used. Below this limit,
+                    the dynamic range is linearly unlocked according to consumption.
+                    Set BAT${i}_DYNACT to "Consumption based" to use.
+            type: float
+            unit: mAh
+            min: 0.0
+            max: 100000
+            decimal: 0
+            increment: 50
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: [0.0, 0.0]
+
+        BAT${i}_DYNACT:
+            description:
+                short: Dynamic actuator range mode for battery ${i}.
+                long: |
+                    Select the dynamic acruator range mode for the battery.
+            type: enum
+            values:
+                -1: Disabled - dynamic range always disabled
+                0: Disabled - dynamic range always enabled
+                1: Consumption based - require full battery
+                2: Consumption based - do not require full battery
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: [0, 0]

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -49,6 +49,7 @@
 #include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/actuator_outputs.h>
+#include <uORB/topics/battery_status.h>
 #include <uORB/topics/control_allocator_status.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/test_motor.h>
@@ -276,6 +277,7 @@ private:
 	uint16_t _disarmed_value[MAX_ACTUATORS] {};
 	uint16_t _min_value[MAX_ACTUATORS] {};
 	uint16_t _max_value[MAX_ACTUATORS] {};
+	uint16_t _dynamic_max_value[MAX_ACTUATORS] {};
 	uint16_t _current_output_value[MAX_ACTUATORS] {}; ///< current output values (reordered)
 	uint16_t _reverse_output_mask{0}; ///< reverses the interval [min, max] -> [max, min], NOT motor direction
 
@@ -290,6 +292,7 @@ private:
 	const bool _output_ramp_up; ///< if true, motors will ramp up from disarmed to min_output after arming
 
 	uORB::Subscription _armed_sub{ORB_ID(actuator_armed)};
+	uORB::Subscription _battery_sub{ORB_ID(battery_status)};
 	uORB::SubscriptionCallbackWorkItem _control_subs[actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS];
 
 	uORB::PublicationMulti<actuator_outputs_s> _outputs_pub{ORB_ID(actuator_outputs)};
@@ -337,6 +340,11 @@ private:
 	const char *const _param_prefix;
 	ParamHandles _param_handles[MAX_ACTUATORS];
 	param_t _param_handle_rev_range{PARAM_INVALID};
+	param_t _param_handle_dynamic_range{PARAM_INVALID};
+	param_t _param_handle_dynamic_channels{PARAM_INVALID};
+	float _dynamic_actuator = 0.f;  // from battery subscription. Init to 0 assumes full battery until data is received.
+	float _dynamic_range = 0.f;
+	int32_t _dynamic_channels = 0;
 	hrt_abstime _lowrate_schedule_interval{300_ms};
 	ActuatorTest _actuator_test{_function_assignment};
 	uint32_t _reversible_mask{0}; ///< per-output bits. If set, the output is configured to be reversible (motors only)

--- a/src/lib/pwm/pwm_aux_params.yaml
+++ b/src/lib/pwm/pwm_aux_params.yaml
@@ -6,6 +6,39 @@ parameters:
     - group: PWM Outputs
       definitions:
 
+        PWM_AUX_DCHNS:
+            description:
+                short: Outputs with dynamic max limiting
+                long: |
+                    The selected outputs will reduce the max output
+                    based on PWM_AUX_DRNG and the dynamic allocator
+                    signal received from the battery module.
+            type: bitmask
+            bit:
+                0: Channel 1
+                1: Channel 2
+                2: Channel 3
+                3: Channel 4
+                4: Channel 5
+                5: Channel 6
+                6: Channel 7
+                7: Channel 8
+            default: 0
+
+        PWM_AUX_DRNG:
+            description:
+                short: Amount to reduce max limit, given a full battery
+                long: |
+                    The outputs given by PWM_AUX_DCHNS will have a reduction
+                    in output range (max-min) given by this scalar when the
+                    battery is full. The output will gradually be scaled up
+                    as the battery is drained.
+            type: float
+            min: 0
+            max: 1
+            decimal: 2
+            default: 0
+
         PWM_AUX_OUT:
             description:
                 short: PWM channels used as ESC outputs

--- a/src/lib/pwm/pwm_extra_params.yaml
+++ b/src/lib/pwm/pwm_extra_params.yaml
@@ -6,6 +6,39 @@ parameters:
     - group: PWM Outputs
       definitions:
 
+        PWM_EXTRA_DCHNS:
+            description:
+                short: Outputs with dynamic max limiting
+                long: |
+                    The selected outputs will reduce the max output
+                    based on PWM_EXTRA_DRNG and the dynamic allocator
+                    signal received from the battery module.
+            type: bitmask
+            bit:
+                0: Channel 1
+                1: Channel 2
+                2: Channel 3
+                3: Channel 4
+                4: Channel 5
+                5: Channel 6
+                6: Channel 7
+                7: Channel 8
+            default: 0
+
+        PWM_EXTRA_DRNG:
+            description:
+                short: Amount to reduce max limit, given a full battery
+                long: |
+                    The outputs given by PWM_EXTRA_DCHNS will have a reduction
+                    in output range (max-min) given by this scalar when the
+                    battery is full. The output will gradually be scaled up
+                    as the battery is drained.
+            type: float
+            min: 0
+            max: 1
+            decimal: 2
+            default: 0
+
         PWM_EXTRA_RATE:
             description:
                 short: PWM extra output frequency

--- a/src/lib/pwm/pwm_main_params.yaml
+++ b/src/lib/pwm/pwm_main_params.yaml
@@ -6,6 +6,45 @@ parameters:
     - group: PWM Outputs
       definitions:
 
+        PWM_MAIN_DCHNS:
+            description:
+                short: Outputs with dynamic max limiting
+                long: |
+                    The selected outputs will reduce the max output
+                    based on PWM_MAIN_DRNG and the dynamic allocator
+                    signal received from the battery module.
+            type: bitmask
+            bit:
+                0: Channel 1
+                1: Channel 2
+                2: Channel 3
+                3: Channel 4
+                4: Channel 5
+                5: Channel 6
+                6: Channel 7
+                7: Channel 8
+                8: Channel 9
+                9: Channel 10
+                10: Channel 11
+                11: Channel 12
+                12: Channel 13
+                13: Channel 14
+            default: 0
+
+        PWM_MAIN_DRNG:
+            description:
+                short: Amount to reduce max limit, given a full battery
+                long: |
+                    The outputs given by PWM_MAIN_DCHNS will have a reduction
+                    in output range (max-min) given by this scalar when the
+                    battery is full. The output will gradually be scaled up
+                    as the battery is drained.
+            type: float
+            min: 0
+            max: 1
+            decimal: 2
+            default: 0
+
         PWM_MAIN_OUT:
             description:
                 short: PWM channels used as ESC outputs

--- a/src/modules/commander/Arming/PreFlightCheck/CMakeLists.txt
+++ b/src/modules/commander/Arming/PreFlightCheck/CMakeLists.txt
@@ -52,6 +52,7 @@ px4_add_library(PreFlightCheck
 	checks/cpuResourceCheck.cpp
 	checks/sdcardCheck.cpp
 	checks/parachuteCheck.cpp
+	checks/dynamicActuatorCheck.cpp
 )
 target_include_directories(PreFlightCheck PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(PreFlightCheck PUBLIC ArmAuthorization HealthFlags sensor_calibration)

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -228,6 +228,11 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 	failed = failed || !cpuResourceCheck(mavlink_log_pub, report_failures);
 	failed = failed || !parachuteCheck(mavlink_log_pub, report_failures, status_flags);
 
+	// Check first instance of battery status for dynamic actuator,
+	// since only first instance is curretly used in mixer module.
+	// Need to expand this if we ever subscribe to other intances in mixer module.
+	failed = failed || !dynamicActuatorCheck(mavlink_log_pub, 0, true, report_failures);
+
 	/* Report status */
 	return !failed;
 }

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -138,4 +138,6 @@ private:
 	static bool sdcardCheck(orb_advert_t *mavlink_log_pub, bool &sd_card_detected_once, const bool report_fail);
 	static bool parachuteCheck(orb_advert_t *mavlink_log_pub, const bool report_fail,
 				   const vehicle_status_flags_s &status_flags);
+	static bool dynamicActuatorCheck(orb_advert_t *mavlink_log_pub, const uint8_t instance,
+					 const bool is_mandatory, const bool report_fail);
 };

--- a/src/modules/commander/Arming/PreFlightCheck/checks/dynamicActuatorCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/dynamicActuatorCheck.cpp
@@ -1,0 +1,30 @@
+#include "../PreFlightCheck.hpp"
+
+#include <drivers/drv_hrt.h>
+#include <px4_defines.h>
+#include <systemlib/mavlink_log.h>
+#include <uORB/uORB.h>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/battery_status.h>
+
+using namespace time_literals;
+
+bool PreFlightCheck::dynamicActuatorCheck(orb_advert_t *mavlink_log_pub, const uint8_t instance,
+		const bool is_mandatory, const bool report_fail)
+{
+	uORB::SubscriptionData<battery_status_s> battery_status_sub{ORB_ID(battery_status), instance};
+	battery_status_sub.update();
+	const battery_status_s &battery_status_data = battery_status_sub.get();
+
+	bool valid = (hrt_elapsed_time(&battery_status_data.timestamp) < 5_s);
+	bool good = battery_status_data.dynamic_actuator >= 0.f;
+
+	if (!valid && report_fail) {
+		mavlink_log_critical(mavlink_log_pub, "Preflight Fail: no valid data from battery %u", instance);
+
+	} else if (!good && report_fail) {
+		mavlink_log_critical(mavlink_log_pub, "Preflight Fail: dynamic actuator error from battery %u", instance);
+	}
+
+	return (valid && good) || !is_mandatory;
+}

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -122,7 +122,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("wind", 1000);
 
 	// multi topics
-	add_optional_topic_multi("actuator_outputs", 100, 3);
+	add_optional_topic_multi("actuator_outputs", 100, 5); // UAVCAN servo, UAVCAN ESC, PWM MAIN, PWM AUX, DSHOT AUX
 	add_optional_topic_multi("airspeed_wind", 1000, 4);
 	// By making it non-optional, we don't need to start uavcan before the logger module
 	add_topic_multi("can_interface_status", 100, 2);
@@ -263,8 +263,10 @@ void LoggedTopics::add_high_rate_topics()
 
 void LoggedTopics::add_aviant_high_rate_topics()
 {
-	add_topic("actuator_controls_0");
-	add_topic("actuator_outputs");
+	add_topic("vehicle_torque_setpoint", 0, 0); // Torque setpoint of motors
+	add_topic("vehicle_thrust_setpoint", 0, 0); // Thrust setpoint of motors
+	add_topic("vehicle_torque_setpoint", 0, 1); // Torque setpoint of servos
+	// add_topic("vehicle_thrust_setpoint", 0, 1); // Thrust setpoint of servos, always 0
 	add_topic("sensor_combined");
 	add_topic("sensor_accel", 0, 2);
 	add_topic("sensor_gyro", 0, 2);


### PR DESCRIPTION
As far as I can see, dynamic PWM limiting should work magically on DSHOT too. Basically, PWM_MAIN_MIN/MAX are applied before PX4 know if it's outputting DSHOT or PWM. Must test on the table first, though.

- [ ] Verify that DSHOT limiting works
- [ ] Ground test and very that actuators work