### PR TITLE
battery: add support for NTC battery thermistor in ADC port

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -111,6 +111,11 @@ void Battery::updateCurrent(const float current_a)
 	_current_filter_a.update(current_a);
 }
 
+void Battery::updateTemperature(const float temperature_c)
+{
+	_temperature_c = temperature_c;
+}
+
 void Battery::updateBatteryStatus(const hrt_abstime &timestamp)
 {
 	if (!_battery_initialized) {
@@ -146,7 +151,7 @@ battery_status_s Battery::getBatteryStatus()
 	battery_status.remaining = _state_of_charge;
 	battery_status.scale = _scale;
 	battery_status.time_remaining_s = computeRemainingTime(_current_a);
-	battery_status.temperature = NAN;
+	battery_status.temperature = _temperature_c;
 	battery_status.cell_count = _params.n_cells;
 	battery_status.connected = _connected;
 	battery_status.source = _source;

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -90,6 +90,7 @@ public:
 	void setConnected(const bool connected) { _connected = connected; }
 	void updateVoltage(const float voltage_v);
 	void updateCurrent(const float current_a);
+	void updateTemperature(const float temperature_c);
 
 	/**
 	 * Update state of charge calculations
@@ -168,6 +169,7 @@ private:
 	float _state_of_charge_volt_based{-1.f}; // [0,1]
 	float _state_of_charge{-1.f}; // [0,1]
 	float _scale{1.f};
+	float _temperature_c{NAN};
 	uint8_t _warning{battery_status_s::BATTERY_WARNING_NONE};
 	hrt_abstime _last_timestamp{0};
 	bool _armed{false};

--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -31,9 +31,14 @@
  *
  ****************************************************************************/
 
+#include <cmath>
 #include <stdio.h>
 #include <lib/battery/battery.h>
 #include "analog_battery.h"
+#include "drivers/drv_hrt.h"
+#include "px4_platform_common/defines.h"
+
+using namespace time_literals;
 
 // Defaults to use if the parameters are not set
 #if BOARD_NUMBER_BRICKS > 0
@@ -68,19 +73,58 @@ AnalogBattery::AnalogBattery(int index, ModuleParams *parent, const int sample_i
 
 	snprintf(param_name, sizeof(param_name), "BAT%d_I_CHANNEL", index);
 	_analog_param_handles.i_channel = param_find(param_name);
+
+	snprintf(param_name, sizeof(param_name), "BAT%d_T_CHANNEL", index);
+	_analog_param_handles.t_channel = param_find(param_name);
+
+	snprintf(param_name, sizeof(param_name), "BAT%d_T_R_PU", index);
+	_analog_param_handles.t_r_pu = param_find(param_name);
+
+	snprintf(param_name, sizeof(param_name), "BAT%d_T_R_25C", index);
+	_analog_param_handles.t_r_25c = param_find(param_name);
+
+	snprintf(param_name, sizeof(param_name), "BAT%d_T_BETA", index);
+	_analog_param_handles.t_beta = param_find(param_name);
 }
 
+
 void
-AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw)
+AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw,
+				      float temperature_raw)
 {
 	const float voltage_v = voltage_raw * _analog_params.v_div;
 	const float current_a = (current_raw - _analog_params.v_offs_cur) * _analog_params.a_per_v;
+
+	static constexpr float zero_c_in_k = 273.15f;
+	static constexpr float epsilon = 1e-6f;
+	static constexpr hrt_abstime system_power_stale_timeout = 2_s;
+
+	float temperature_c = NAN;
+	system_power_s system_power{};
+
+	if (_system_power_sub.copy(&system_power) && hrt_elapsed_time(&system_power.timestamp) < system_power_stale_timeout) {
+		const float thermistor_pullup_v = system_power.voltage5v_v - temperature_raw;
+		const float thermistor_ohm_inf = _analog_params.t_r_25c * expf(-_analog_params.t_beta / (zero_c_in_k + 25.f));
+
+		if (thermistor_pullup_v > epsilon && thermistor_ohm_inf > epsilon) {
+			const float thermistor_ohm = _analog_params.t_r_pu * temperature_raw / thermistor_pullup_v;
+			const float thermistor_ohm_ratio = thermistor_ohm / thermistor_ohm_inf;
+
+			const float log_thermistor_ohm_ratio = thermistor_ohm_ratio > epsilon ? logf(thermistor_ohm_ratio) : NAN;
+
+			if (PX4_ISFINITE(log_thermistor_ohm_ratio) && log_thermistor_ohm_ratio > epsilon) {
+				temperature_c = _analog_params.t_beta / log_thermistor_ohm_ratio - zero_c_in_k;
+			}
+		}
+	}
+
 
 	const bool connected = voltage_v > BOARD_ADC_OPEN_CIRCUIT_V &&
 			       (BOARD_ADC_OPEN_CIRCUIT_V <= BOARD_VALID_UV || is_valid());
 
 	Battery::setConnected(connected);
 	Battery::updateVoltage(voltage_v);
+	Battery::updateTemperature(temperature_c);
 	Battery::updateCurrent(current_a);
 	Battery::updateAndPublishBatteryStatus(timestamp);
 }
@@ -116,6 +160,16 @@ int AnalogBattery::get_current_channel()
 	}
 }
 
+int AnalogBattery::get_temperature_channel()
+{
+	if (_analog_params.t_channel >= 0) {
+		return _analog_params.t_channel;
+
+	} else {
+		return -1; // No temperature channel
+	}
+}
+
 void
 AnalogBattery::updateParams()
 {
@@ -123,6 +177,10 @@ AnalogBattery::updateParams()
 	param_get(_analog_param_handles.a_per_v, &_analog_params.a_per_v);
 	param_get(_analog_param_handles.v_channel, &_analog_params.v_channel);
 	param_get(_analog_param_handles.i_channel, &_analog_params.i_channel);
+	param_get(_analog_param_handles.t_channel, &_analog_params.t_channel);
+	param_get(_analog_param_handles.t_r_pu, &_analog_params.t_r_pu);
+	param_get(_analog_param_handles.t_r_25c, &_analog_params.t_r_25c);
+	param_get(_analog_param_handles.t_beta, &_analog_params.t_beta);
 	param_get(_analog_param_handles.v_offs_cur, &_analog_params.v_offs_cur);
 
 	Battery::updateParams();

--- a/src/modules/battery_status/analog_battery.h
+++ b/src/modules/battery_status/analog_battery.h
@@ -35,6 +35,8 @@
 
 #include <battery/battery.h>
 #include <parameters/param.h>
+#include <uORB/topics/system_power.h>
+#include <uORB/Subscription.hpp>
 
 class AnalogBattery : public Battery
 {
@@ -47,11 +49,12 @@ public:
 	 *
 	 * @param voltage_raw Battery voltage read from ADC, volts
 	 * @param current_raw Voltage of current sense resistor, volts
+	 * @param temperature_raw Voltage of battery thermistor, volts
 	 * @param timestamp Time at which the ADC was read (use hrt_absolute_time())
 	 * @param source The source as defined by param BAT%d_SOURCE
 	 * @param priority: The brick number -1. The term priority refers to the Vn connection on the LTC4417
 	 */
-	void updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw);
+	void updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw, float temperature_raw);
 
 	/**
 	 * Whether the ADC channel for the voltage of this battery is valid.
@@ -69,6 +72,11 @@ public:
 	 */
 	int get_current_channel();
 
+	/**
+	 * Which ADC channel is used for temperature reading of this battery
+	 */
+	int get_temperature_channel();
+
 protected:
 
 	struct {
@@ -77,6 +85,10 @@ protected:
 		param_t a_per_v;
 		param_t v_channel;
 		param_t i_channel;
+		param_t t_channel;
+		param_t t_r_pu;
+		param_t t_r_25c;
+		param_t t_beta;
 	} _analog_param_handles;
 
 	struct {
@@ -85,7 +97,13 @@ protected:
 		float a_per_v;
 		int32_t v_channel;
 		int32_t i_channel;
+		int32_t t_channel;
+		float t_r_pu;
+		float t_r_25c;
+		float t_beta;
 	} _analog_params;
+
+	uORB::Subscription _system_power_sub{ORB_ID(system_power)};
 
 	virtual void updateParams() override;
 };

--- a/src/modules/battery_status/battery_status.cpp
+++ b/src/modules/battery_status/battery_status.cpp
@@ -177,6 +177,7 @@ BatteryStatus::adc_poll()
 	/* Per Brick readings with default unread channels at 0 */
 	float bat_current_adc_readings[BOARD_NUMBER_BRICKS] {};
 	float bat_voltage_adc_readings[BOARD_NUMBER_BRICKS] {};
+	float bat_temperature_adc_readings[BOARD_NUMBER_BRICKS] {NAN};
 	bool has_bat_voltage_adc_channel[BOARD_NUMBER_BRICKS] {};
 
 	int selected_source = -1;
@@ -214,9 +215,13 @@ BatteryStatus::adc_poll()
 						bat_current_adc_readings[b] = adc_report.raw_data[i] *
 									      adc_report.v_ref /
 									      adc_report.resolution;
+
+					} else if (adc_report.channel_id[i] == _analogBatteries[b]->get_temperature_channel()) {
+						bat_temperature_adc_readings[b] = adc_report.raw_data[i] *
+										  adc_report.v_ref /
+										  adc_report.resolution;
 					}
 				}
-
 			}
 		}
 
@@ -226,7 +231,8 @@ BatteryStatus::adc_poll()
 				_analogBatteries[b]->updateBatteryStatusADC(
 					hrt_absolute_time(),
 					bat_voltage_adc_readings[b],
-					bat_current_adc_readings[b]
+					bat_current_adc_readings[b],
+					bat_temperature_adc_readings[b]
 				);
 			}
 		}

--- a/src/modules/battery_status/module.yaml
+++ b/src/modules/battery_status/module.yaml
@@ -61,3 +61,62 @@ parameters:
             num_instances: *max_num_config_instances
             instance_start: 1
             default: [-1, -1]
+
+        BAT${i}_T_CHANNEL:
+            description:
+                short: Battery ${i} Temperature ADC Channel
+                long: |
+                    This parameter specifies the ADC channel used to monitor temperature of main power battery.
+                    The ADC is assumed to be reading from a voltage divider with a thermistor and pullup resistor,
+                    using system power as the voltage source. See the other BAT{i}_T_* parameters for configuration.
+                    A value of -1 means no channel. Note that this is different from voltage and current configuration.
+
+            type: int32
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: [-1, -1]
+
+        BAT${i}_T_R_PU:
+            description:
+                short: Battery ${i} Temperature pull-up resistor
+                long: |
+                    This parameter specifies the pull-up resistor wired in series with the NTC thermistor.
+                    The value is in ohms.
+
+            type: float
+            unit: Ohm
+            decimal: 8
+            min: 1
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: 5148
+
+        BAT${i}_T_R_25C:
+            description:
+                short: Battery ${i} NTC Thermistor resistance at 25 degrees C
+                long: |
+                    This parameter specifies the thermistor resistance at 25 degrees C.
+                    An NTC thermistor is assumed.
+
+            type: float
+            unit: Ohm
+            decimal: 8
+            min: 1
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: 10000
+
+        BAT${i}_T_BETA:
+            description:
+                short: Battery ${i} Thermistor Beta
+                long: |
+                    This parameter specifies the beta value for the battery thermistor,
+                    which indicates the shape of the temperature vs resistance curve.
+                    An NTC thermistor is assumed.
+
+            type: float
+            decimal: 8
+            min: 1
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: 3988


### PR DESCRIPTION
Off by default, enable using the parameter BAT{i}_T_CHANNEL