### PR TITLE
ms4525do: check all data bits, not just the msb part

### DIFF
--- a/src/drivers/differential_pressure/ms4525do/MS4525DO.cpp
+++ b/src/drivers/differential_pressure/ms4525do/MS4525DO.cpp
@@ -172,7 +172,7 @@ void MS4525DO::RunImpl()
 				perf_count(_fault_perf);
 
 			} else if ((status_1 == (uint8_t)STATUS::Normal_Operation) && (status_2 == (uint8_t)STATUS::Stale_Data)
-				   && (bridge_data_1_msb == bridge_data_2_msb) && (temperature_1 == temperature_2)) {
+				   && (bridge_data_1 == bridge_data_2) && (temperature_1 == temperature_2)) {
 
 				float temperature_c = ((200.f * temperature_1) / 2047) - 50.f;
 

--- a/src/drivers/differential_pressure/ms4525do/MS4525DO.cpp
+++ b/src/drivers/differential_pressure/ms4525do/MS4525DO.cpp
@@ -46,6 +46,7 @@ MS4525DO::~MS4525DO()
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
 	perf_free(_fault_perf);
+	perf_free(_corrupted_samples_perf);
 }
 
 int MS4525DO::probe()
@@ -109,6 +110,7 @@ void MS4525DO::print_status()
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
 	perf_print_counter(_fault_perf);
+	perf_print_counter(_corrupted_samples_perf);
 }
 
 void MS4525DO::RunImpl()
@@ -209,6 +211,7 @@ void MS4525DO::RunImpl()
 				}
 
 			} else {
+				perf_count(_corrupted_samples_perf);
 				PX4_DEBUG("status:%X|%X, B:%X|%X, T:%X|%X", status_1, status_2, bridge_data_1, bridge_data_2, temperature_1,
 					  temperature_2);
 			}

--- a/src/drivers/differential_pressure/ms4525do/MS4525DO.hpp
+++ b/src/drivers/differential_pressure/ms4525do/MS4525DO.hpp
@@ -93,5 +93,5 @@ private:
 
 	perf_counter_t _sample_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": read")};
 	perf_counter_t _comms_errors{perf_alloc(PC_COUNT, MODULE_NAME": communication errors")};
-	perf_counter_t _fault_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": fault detected")};
+	perf_counter_t _fault_perf{perf_alloc(PC_COUNT, MODULE_NAME": fault detected")};
 };

--- a/src/drivers/differential_pressure/ms4525do/MS4525DO.hpp
+++ b/src/drivers/differential_pressure/ms4525do/MS4525DO.hpp
@@ -94,4 +94,5 @@ private:
 	perf_counter_t _sample_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": read")};
 	perf_counter_t _comms_errors{perf_alloc(PC_COUNT, MODULE_NAME": communication errors")};
 	perf_counter_t _fault_perf{perf_alloc(PC_COUNT, MODULE_NAME": fault detected")};
+	perf_counter_t _corrupted_samples_perf{perf_alloc(PC_COUNT, MODULE_NAME": corrupted samples detected")};
 };


### PR DESCRIPTION
I discovered this bug while troubleshooting the NT06 airspeed problems. The bug does not fully explain the observed behaviour, but I am still convinced that it's a bug and worth fixing.
It's hard to evaluate how much it has impacted our airspeed readings in practice because we have no other measurements to compare against, but in theory a single bitflip can change the readings by close to 10m/s during multirotor flight as shown in the attached graph. A bit less in fixed-wing since airspeed changes with the square root of pressure.

<img width="1543" height="1174" alt="image" src="https://github.com/user-attachments/assets/77dc1f33-498b-43f9-9143-013a4e197205" />
The figure is from F7048 using https://github.com/aviant-tech/various_scripts/blob/main/airspeed_bitflip_analysis.py
