### PR TITLE
fix: use parameter for thermistor source voltage

### DIFF
--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -85,6 +85,9 @@ AnalogBattery::AnalogBattery(int index, ModuleParams *parent, const int sample_i
 
 	snprintf(param_name, sizeof(param_name), "BAT%d_T_BETA", index);
 	_analog_param_handles.t_beta = param_find(param_name);
+
+	snprintf(param_name, sizeof(param_name), "BAT%d_T_V_SRC", index);
+	_analog_param_handles.t_v_src = param_find(param_name);
 }
 
 
@@ -97,24 +100,20 @@ AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, 
 
 	static constexpr float zero_c_in_k = 273.15f;
 	static constexpr float epsilon = 1e-6f;
-	static constexpr hrt_abstime system_power_stale_timeout = 2_s;
 
 	float temperature_c = NAN;
-	system_power_s system_power{};
 
-	if (_system_power_sub.copy(&system_power) && hrt_elapsed_time(&system_power.timestamp) < system_power_stale_timeout) {
-		const float thermistor_pullup_v = system_power.voltage5v_v - temperature_raw;
-		const float thermistor_ohm_inf = _analog_params.t_r_25c * expf(-_analog_params.t_beta / (zero_c_in_k + 25.f));
+	const float thermistor_pullup_v = _analog_params.t_v_src - temperature_raw;
+	const float thermistor_ohm_inf = _analog_params.t_r_25c * expf(-_analog_params.t_beta / (zero_c_in_k + 25.f));
 
-		if (thermistor_pullup_v > epsilon && thermistor_ohm_inf > epsilon) {
-			const float thermistor_ohm = _analog_params.t_r_pu * temperature_raw / thermistor_pullup_v;
-			const float thermistor_ohm_ratio = thermistor_ohm / thermistor_ohm_inf;
+	if (thermistor_pullup_v > epsilon && thermistor_ohm_inf > epsilon) {
+		const float thermistor_ohm = _analog_params.t_r_pu * temperature_raw / thermistor_pullup_v;
+		const float thermistor_ohm_ratio = thermistor_ohm / thermistor_ohm_inf;
 
-			const float log_thermistor_ohm_ratio = thermistor_ohm_ratio > epsilon ? logf(thermistor_ohm_ratio) : NAN;
+		const float log_thermistor_ohm_ratio = thermistor_ohm_ratio > epsilon ? logf(thermistor_ohm_ratio) : NAN;
 
-			if (PX4_ISFINITE(log_thermistor_ohm_ratio) && log_thermistor_ohm_ratio > epsilon) {
-				temperature_c = _analog_params.t_beta / log_thermistor_ohm_ratio - zero_c_in_k;
-			}
+		if (PX4_ISFINITE(log_thermistor_ohm_ratio) && log_thermistor_ohm_ratio > epsilon) {
+			temperature_c = _analog_params.t_beta / log_thermistor_ohm_ratio - zero_c_in_k;
 		}
 	}
 
@@ -181,6 +180,7 @@ AnalogBattery::updateParams()
 	param_get(_analog_param_handles.t_r_pu, &_analog_params.t_r_pu);
 	param_get(_analog_param_handles.t_r_25c, &_analog_params.t_r_25c);
 	param_get(_analog_param_handles.t_beta, &_analog_params.t_beta);
+	param_get(_analog_param_handles.t_v_src, &_analog_params.t_v_src);
 	param_get(_analog_param_handles.v_offs_cur, &_analog_params.v_offs_cur);
 
 	Battery::updateParams();

--- a/src/modules/battery_status/analog_battery.h
+++ b/src/modules/battery_status/analog_battery.h
@@ -89,6 +89,7 @@ protected:
 		param_t t_r_pu;
 		param_t t_r_25c;
 		param_t t_beta;
+		param_t t_v_src;
 	} _analog_param_handles;
 
 	struct {
@@ -101,6 +102,7 @@ protected:
 		float t_r_pu;
 		float t_r_25c;
 		float t_beta;
+		float t_v_src;
 	} _analog_params;
 
 	uORB::Subscription _system_power_sub{ORB_ID(system_power)};

--- a/src/modules/battery_status/module.yaml
+++ b/src/modules/battery_status/module.yaml
@@ -120,3 +120,17 @@ parameters:
             num_instances: *max_num_config_instances
             instance_start: 1
             default: 3988
+
+        BAT${i}_T_V_SRC:
+            description:
+                short: Battery ${i} Thermistor Voltage divider source voltage
+                long: |
+                    This parameter specifies the source voltage for the voltage divider
+                    which the thermistor is in.
+
+            type: float
+            decimal: 3
+            min: 1
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: 3.3


### PR DESCRIPTION
Previous solution assumed that the thermistor voltage divider was connected to the 5v rail, which was readable through system_power. We changed the source voltage to 3.3v, for which there is no good measurement available over uorb. Instead of just hardcoding, a parameter is introduced for future flexibility.

One instance was tested in the temperature chamber in the lab. Got <1degC error from room temperature 24degC down to -10degC, and <2degC error down to -20degC.
It's hard to say anything about the expected measurement accuracy for any instance without measuring the actual 3.3v error of many cube instances. IMO we have reason to believe that the 3.3v will be more stable than the 5v rail, since it's regulated internally in the cube. We should pick it back up if we see suspicious temperature measurements during operation.