### PR TITLE
Revert bitcheck and add more airspeed perf counter

### DIFF
--- a/msg/differential_pressure.msg
+++ b/msg/differential_pressure.msg
@@ -8,3 +8,5 @@ float32 differential_pressure_pa     # differential pressure reading in Pascals 
 float32 temperature                  # Temperature provided by sensor in celcius, NAN if unknown
 
 uint32 error_count                   # Number of errors detected by driver
+
+uint32 accepted_corrupted_msgs_count # Number of messages let through with corrupted bits

--- a/src/drivers/differential_pressure/ms4525do/MS4525DO.cpp
+++ b/src/drivers/differential_pressure/ms4525do/MS4525DO.cpp
@@ -47,6 +47,7 @@ MS4525DO::~MS4525DO()
 	perf_free(_comms_errors);
 	perf_free(_fault_perf);
 	perf_free(_corrupted_samples_perf);
+	perf_free(_corrupted_accepted_lsb_samples_perf);
 }
 
 int MS4525DO::probe()
@@ -111,6 +112,7 @@ void MS4525DO::print_status()
 	perf_print_counter(_comms_errors);
 	perf_print_counter(_fault_perf);
 	perf_print_counter(_corrupted_samples_perf);
+	perf_print_counter(_corrupted_accepted_lsb_samples_perf);
 }
 
 void MS4525DO::RunImpl()
@@ -177,6 +179,10 @@ void MS4525DO::RunImpl()
 				   && (bridge_data_1_msb == bridge_data_2_msb) && (temperature_1 == temperature_2)) {
 
 				float temperature_c = ((200.f * temperature_1) / 2047) - 50.f;
+
+				if (bridge_data_1_lsb != bridge_data_2_lsb) {
+					perf_count(_corrupted_accepted_lsb_samples_perf);
+				}
 
 				// Output is proportional to the difference between Port 1 and Port 2. Output swings
 				// positive when Port 1> Port 2. Output is 50% of supply voltage when Port 1=Port 2.

--- a/src/drivers/differential_pressure/ms4525do/MS4525DO.cpp
+++ b/src/drivers/differential_pressure/ms4525do/MS4525DO.cpp
@@ -209,7 +209,8 @@ void MS4525DO::RunImpl()
 					differential_pressure.device_id = get_device_id();
 					differential_pressure.differential_pressure_pa = diff_press_pa;
 					differential_pressure.temperature = temperature_c;
-					differential_pressure.error_count = perf_event_count(_comms_errors);
+					differential_pressure.error_count = perf_event_count(_fault_perf);
+					differential_pressure.accepted_corrupted_msgs_count = perf_event_count(_corrupted_accepted_lsb_samples_perf);
 					differential_pressure.timestamp = hrt_absolute_time();
 					_differential_pressure_pub.publish(differential_pressure);
 

--- a/src/drivers/differential_pressure/ms4525do/MS4525DO.cpp
+++ b/src/drivers/differential_pressure/ms4525do/MS4525DO.cpp
@@ -174,7 +174,7 @@ void MS4525DO::RunImpl()
 				perf_count(_fault_perf);
 
 			} else if ((status_1 == (uint8_t)STATUS::Normal_Operation) && (status_2 == (uint8_t)STATUS::Stale_Data)
-				   && (bridge_data_1 == bridge_data_2) && (temperature_1 == temperature_2)) {
+				   && (bridge_data_1_msb == bridge_data_2_msb) && (temperature_1 == temperature_2)) {
 
 				float temperature_c = ((200.f * temperature_1) / 2047) - 50.f;
 

--- a/src/drivers/differential_pressure/ms4525do/MS4525DO.hpp
+++ b/src/drivers/differential_pressure/ms4525do/MS4525DO.hpp
@@ -94,5 +94,6 @@ private:
 	perf_counter_t _sample_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": read")};
 	perf_counter_t _comms_errors{perf_alloc(PC_COUNT, MODULE_NAME": communication errors")};
 	perf_counter_t _fault_perf{perf_alloc(PC_COUNT, MODULE_NAME": fault detected")};
-	perf_counter_t _corrupted_samples_perf{perf_alloc(PC_COUNT, MODULE_NAME": corrupted samples detected")};
+	perf_counter_t _corrupted_samples_perf{perf_alloc(PC_COUNT, MODULE_NAME": corrupted samples discarded")};
+	perf_counter_t _corrupted_accepted_lsb_samples_perf{perf_alloc(PC_COUNT, MODULE_NAME": samples accpted with corrupted LSBs")};
 };


### PR DESCRIPTION
NT16 has large amount of discarded airspeed samples. We want to revert to the upstream bitcheck, but add logging for how many samples with flipped LSBs are getting through

https://fms.aviant.no/flight/7269/show

Screenshot from a random cube on my desk
<img width="1006" height="568" alt="image" src="https://github.com/user-attachments/assets/0068b135-7349-4e04-a528-1d56d184e4c6" />

We should consider also changing the `differential_pressure.error_count` field to one of these new perf counters instead of `_comms_errors`, to get the count over time, what do you think @oystub ?