### PR TITLE
Aviant/gps fixes

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -106,7 +106,7 @@ struct GPS_Sat_Info {
 	satellite_info_s _data;
 };
 
-static constexpr int TASK_STACK_SIZE = PX4_STACK_ADJUSTED(1760);
+static constexpr int TASK_STACK_SIZE = PX4_STACK_ADJUSTED(1990);
 
 
 class GPS : public ModuleBase<GPS>, public device::Device

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -106,7 +106,7 @@ struct GPS_Sat_Info {
 	satellite_info_s _data;
 };
 
-static constexpr int TASK_STACK_SIZE = PX4_STACK_ADJUSTED(1990);
+static constexpr int TASK_STACK_SIZE = PX4_STACK_ADJUSTED(2040);
 
 
 class GPS : public ModuleBase<GPS>, public device::Device


### PR DESCRIPTION
**Increase GPS driver stack size**
We get low stack warnings in our latest gps heading firmware, which are annoying.
I also suspect this can cause boot loops for GPS2.

Done this by cherry picking the two upstream commits that modified these. Both are in 1.14
https://github.com/PX4/PX4-Autopilot/commits/main/src/drivers/gps/gps.cpp

**Fix formatting in gps driver repo**
As suggested by Torjus