### PR TITLE
Basic jammer test functionality

### DIFF
--- a/msg/vehicle_command.msg
+++ b/msg/vehicle_command.msg
@@ -94,6 +94,8 @@ uint16 VEHICLE_CMD_PAYLOAD_CONTROL_DEPLOY = 30002	# Control a pre-programmed pay
 uint16 VEHICLE_CMD_FIXED_MAG_CAL_YAW = 42006            # Magnetometer calibration based on provided known yaw. This allows for fast calibration using WMM field tables in the vehicle, given only the known yaw of the vehicle. If Latitude and longitude are both zero then use the current vehicle location.
 
 
+uint16 VEHICLE_CMD_EXTERNAL_POSITION_ESTIMATE = 43003 # external reset of estimator global position when deadreckoning
+
 # PX4 vehicle commands (beyond 16 bit mavlink commands)
 uint32 VEHICLE_CMD_PX4_INTERNAL_START    = 65537        # start of PX4 internal only vehicle commands (> UINT16_MAX)
 uint32 VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN = 100000       # Sets the GPS co-ordinates of the vehicle local origin (0,0,0) position. |Empty|Empty|Empty|Empty|Latitude|Longitude|Altitude|

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -550,6 +550,7 @@ union information_event_status_u {
 		bool starting_vision_vel_fusion	: 1; ///< 10 - true when the filter starts using vision system velocity measurements to correct the state estimates
 		bool starting_vision_yaw_fusion	: 1; ///< 11 - true when the filter starts using vision system yaw  measurements to correct the state estimates
 		bool yaw_aligned_to_imu_gps	: 1; ///< 12 - true when the filter resets the yaw to an estimate derived from IMU and GPS data
+		bool reset_pos_to_ext_obs       : 1; ///< 13 - true when horizontal position was reset to an external observation while deadreckoning
 	} flags;
 	uint32_t value;
 };

--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -317,6 +317,7 @@ Ekf::resetGlobalPosToExternalObservation(double lat_deg, double lon_deg, float a
 	Vector2f pos_corrected = _pos_ref.project(lat_deg, lon_deg) + _state.vel.xy() * dt;
 
 	resetHorizontalPositionToExternal(pos_corrected, math::max(accuracy, FLT_EPSILON));
+	_time_last_aiding = _time_last_imu;
 }
 
 /*

--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -299,6 +299,26 @@ void Ekf::predictState()
 	}
 }
 
+void
+Ekf::resetGlobalPosToExternalObservation(double lat_deg, double lon_deg, float accuracy,
+		uint64_t timestamp_observation)
+{
+
+	if (!_pos_ref.isInitialized()) {
+		return;
+	}
+
+	// apply a first order correction using velocity at the delated time horizon and the delta time
+	timestamp_observation = math::min(_newest_high_rate_imu_sample.time_us, timestamp_observation);
+	const float dt = _imu_sample_delayed.time_us > timestamp_observation ? static_cast<float>
+			 (_imu_sample_delayed.time_us - timestamp_observation) * 1e-6f : -static_cast<float>(timestamp_observation -
+					 _imu_sample_delayed.time_us) * 1e-6f;
+
+	Vector2f pos_corrected = _pos_ref.project(lat_deg, lon_deg) + _state.vel.xy() * dt;
+
+	resetHorizontalPositionToExternal(pos_corrected, math::max(accuracy, FLT_EPSILON));
+}
+
 /*
  * Implement a strapdown INS algorithm using the latest IMU data at the current time horizon.
  * Buffer the INS states and calculate the difference with the EKF states at the delayed fusion time horizon.

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -337,6 +337,8 @@ public:
 	const BaroBiasEstimator::status &getBaroBiasEstimatorStatus() const { return _baro_b_est.getStatus(); }
 
     bool get_filter_initialised() const { return _filter_initialised; }
+	void resetGlobalPosToExternalObservation(double lat_deg, double lon_deg, float accuracy,
+			uint64_t timestamp_observation);
 
 private:
 
@@ -656,7 +658,9 @@ private:
 	void resetHorizontalPositionToVision();
 	void resetHorizontalPositionToOpticalFlow();
 	void resetHorizontalPositionToLastKnown();
-	void resetHorizontalPositionTo(const Vector2f &new_horz_pos);
+	void resetHorizontalPositionToExternal(const Vector2f &new_horiz_pos, float horiz_accuracy);
+	void resetHorizontalPositionTo(const Vector2f &new_horz_pos, const Vector2f &new_horz_pos_var);
+	void resetHorizontalPositionTo(const Vector2f &new_horz_pos, const float pos_var = NAN) { resetHorizontalPositionTo(new_horz_pos, Vector2f(pos_var, pos_var)); }
 
 	void resetVerticalPositionTo(float new_vert_pos);
 

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -195,7 +195,7 @@ void Ekf::resetHorizontalPositionToLastKnown()
 	P.uncorrelateCovarianceSetVariance<2>(7, sq(_params.pos_noaid_noise));
 }
 
-void Ekf::resetHorizontalPositionTo(const Vector2f &new_horz_pos)
+void Ekf::resetHorizontalPositionTo(const Vector2f &new_horz_pos, const Vector2f &new_horz_pos_var)
 {
 	const Vector2f delta_horz_pos{new_horz_pos - Vector2f{_state.pos}};
 	_state.pos.xy() = new_horz_pos;
@@ -206,11 +206,26 @@ void Ekf::resetHorizontalPositionTo(const Vector2f &new_horz_pos)
 
 	_output_new.pos.xy() += delta_horz_pos;
 
+	if (PX4_ISFINITE(new_horz_pos_var(0))) {
+		P.uncorrelateCovarianceSetVariance<1>(7, math::max(sq(0.01f), new_horz_pos_var(0)));
+	}
+
+	if (PX4_ISFINITE(new_horz_pos_var(1))) {
+		P.uncorrelateCovarianceSetVariance<1>(8, math::max(sq(0.01f), new_horz_pos_var(1)));
+	}
+
 	_state_reset_status.posNE_change = delta_horz_pos;
 	_state_reset_status.posNE_counter++;
 
 	// Reset the timout timer
 	_time_last_hor_pos_fuse = _time_last_imu;
+}
+
+void Ekf::resetHorizontalPositionToExternal(const Vector2f &new_horiz_pos, float horiz_accuracy)
+{
+	_information_events.flags.reset_pos_to_ext_obs = true;
+	ECL_INFO("reset position to external observation");
+	resetHorizontalPositionTo(new_horiz_pos, sq(horiz_accuracy));
 }
 
 void Ekf::resetVerticalPositionTo(const float new_vert_pos)

--- a/src/modules/ekf2/EKF/fake_pos_control.cpp
+++ b/src/modules/ekf2/EKF/fake_pos_control.cpp
@@ -45,7 +45,7 @@ void Ekf::controlFakePosFusion()
 	const bool fake_pos_data_ready = isTimedOut(_time_last_fake_pos_fuse, (uint64_t)2e5); // Fuse fake position at a limited rate
 
 	if (fake_pos_data_ready) {
-		const bool continuing_conditions_passing = !isHorizontalAidingActive();
+		const bool continuing_conditions_passing = _deadreckon_time_exceeded && !isHorizontalAidingActive();
 		const bool starting_conditions_passing = continuing_conditions_passing;
 
 		if (_using_synthetic_position) {

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -40,6 +40,9 @@ using matrix::Eulerf;
 using matrix::Quatf;
 using matrix::Vector3f;
 
+static constexpr float kDefaultExternalPosAccuracy = 50.0f; // [m]
+static constexpr float kMaxDelaySecondsExternalPosMeasurement = 15.0f; // [s]
+
 pthread_mutex_t ekf2_module_mutex = PTHREAD_MUTEX_INITIALIZER;
 static px4::atomic<EKF2 *> _objects[EKF2_MAX_INSTANCES] {};
 #if !defined(CONSTRAINED_FLASH)
@@ -370,6 +373,26 @@ void EKF2::Run()
 					// Validate the ekf origin status.
 					_ekf.getEkfGlobalOrigin(origin_time, latitude, longitude, altitude);
 					PX4_INFO("New NED origin (LLA): %3.10f, %3.10f, %4.3f\n", latitude, longitude, static_cast<double>(altitude));
+				}
+			}
+
+			if (vehicle_command.command == vehicle_command_s::VEHICLE_CMD_EXTERNAL_POSITION_ESTIMATE) {
+				if ((_ekf.control_status_flags().wind_dead_reckoning || _ekf.control_status_flags().inertial_dead_reckoning) &&
+				    PX4_ISFINITE(vehicle_command.param2) && PX4_ISFINITE(vehicle_command.param5) && PX4_ISFINITE(vehicle_command.param6)) {
+
+					const float measurement_delay_seconds = math::constrain(vehicle_command.param2, 0.0f,
+										kMaxDelaySecondsExternalPosMeasurement);
+					const uint64_t timestamp_observation = vehicle_command.timestamp - measurement_delay_seconds * 1_s;
+
+					float accuracy = kDefaultExternalPosAccuracy;
+
+					if (PX4_ISFINITE(vehicle_command.param3) && vehicle_command.param3 > FLT_EPSILON) {
+						accuracy = vehicle_command.param3;
+					}
+
+					// TODO add check for lat and long validity
+					_ekf.resetGlobalPosToExternalObservation(vehicle_command.param5, vehicle_command.param6,
+							accuracy, timestamp_observation);
 				}
 			}
 		}

--- a/src/modules/ekf2/test/test_EKF_fusionLogic.cpp
+++ b/src/modules/ekf2/test/test_EKF_fusionLogic.cpp
@@ -280,8 +280,8 @@ TEST_F(EkfFusionLogicTest, doVisionPositionFusion)
 
 	// WHEN: stop sending vision data
 	_sensor_simulator.stopExternalVision();
-	 // Need to wait for deadreckon time to exceed before fake position fusion starts
-	_sensor_simulator.runSeconds(7+5);
+	// Need to wait for deadreckon time to exceed before fake position fusion starts
+	_sensor_simulator.runSeconds(7 + 5);
 
 	// THEN: EKF should stop to intend to fuse vision position estimate
 	//       and EKF should not have a valid local position estimate anymore

--- a/src/modules/ekf2/test/test_EKF_fusionLogic.cpp
+++ b/src/modules/ekf2/test/test_EKF_fusionLogic.cpp
@@ -280,7 +280,8 @@ TEST_F(EkfFusionLogicTest, doVisionPositionFusion)
 
 	// WHEN: stop sending vision data
 	_sensor_simulator.stopExternalVision();
-	_sensor_simulator.runSeconds(7);
+	 // Need to wait for deadreckon time to exceed before fake position fusion starts
+	_sensor_simulator.runSeconds(7+5);
 
 	// THEN: EKF should stop to intend to fuse vision position estimate
 	//       and EKF should not have a valid local position estimate anymore

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1526,6 +1526,16 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("VIBRATION", 0.1f);
 		configure_stream_local("WIND_COV", 0.5f);
 
+		// Aviant: Messages for TRN
+		configure_stream_local("ATTITUDE_QUATERNION", 10.0f);
+		configure_stream_local("LOCAL_POSITION_NED", 10.0f);
+		configure_stream_local("GLOBAL_POSITION_INT", 10.f);
+		configure_stream_local("GPS_RAW_INT", 10.0f);
+		configure_stream_local("RAW_PRESSURE", 10.0f);
+		configure_stream_local("SCALED_PRESSURE", 10.0f);
+		configure_stream_local("RAW_IMU", 10.0f);
+		configure_stream_local("ODOMETRY", 10.0f);
+
 #if !defined(CONSTRAINED_FLASH)
 		configure_stream_local("DEBUG", 1.0f);
 		configure_stream_local("DEBUG_FLOAT_ARRAY", 1.0f);

--- a/src/modules/mavlink/streams/LOCAL_POSITION_NED.hpp
+++ b/src/modules/mavlink/streams/LOCAL_POSITION_NED.hpp
@@ -62,7 +62,8 @@ private:
 		vehicle_local_position_s lpos;
 
 		if (_lpos_sub.update(&lpos)) {
-			if (lpos.xy_valid && lpos.v_xy_valid) {
+			//if (lpos.xy_valid && lpos.v_xy_valid) {
+			{
 				mavlink_local_position_ned_t msg{};
 
 				msg.time_boot_ms = lpos.timestamp / 1000;


### PR DESCRIPTION
The target branch `aviant/jammertest_trn` is `aviant/sprind`applied on top of ` v1.13.2-1.13.7` which is currently flashed on NX02.

SPRIND features are required to initialized position without GPS. Even though that branch contains other features as well, I think we should pick the entire flight tested "package".

This PR adds, on top of that:
- ported functionality from 1.15 so that it handles `MAV_CMD_EXTERNAL_POSITION_ESTIMATE` in the same way
- updates MAVLink message rates to those needed by TRN
- handling timestamps in `MAV_CMD_EXTERNAL_POSITION_ESTIMATE` in the way we agreed with KEF
- sends local position over MAVLink, even if it's considered invalid. This is required for TRN
- counts external position reset as aiding, so that `xy_valid` in local position has a chance to be true when using TRN

~~We still have a problem with fake position fusion, since the resets dosen't cont as a velocity or position aiding source. This currently prevents `xy_valid` from becoming true.~~

- FIXED: doesn't re-start fake position fusion unless dead reckoning timeout has triggered. This allows valid position estimate with TRN.

The functionality from these 4 commit has been tested on the ground with NX02