### PR TITLE
navigator: add option to ignore a range of icao addresses

### DIFF
--- a/src/lib/adsb/AdsbConflict.cpp
+++ b/src/lib/adsb/AdsbConflict.cpp
@@ -47,6 +47,14 @@ void AdsbConflict::detect_traffic_conflict(double lat_now, double lon_now, float
 
 {
 
+	if (
+		_transponder_report.icao_address >= _icao_ignore_start &&
+		_transponder_report.icao_address < _icao_ignore_start + _icao_ignore_count
+	) {
+		_conflict_detected = false;
+		return;
+	}
+
 	float d_hor, d_vert;
 	get_distance_to_point_global_wgs84(lat_now, lon_now, alt_now,
 					   _transponder_report.lat, _transponder_report.lon, _transponder_report.altitude, &d_hor, &d_vert);
@@ -232,6 +240,11 @@ void AdsbConflict::set_conflict_detection_params(float crosstrack_separation, fl
 
 }
 
+void AdsbConflict::set_icao_ignore_range(uint32_t start_address, uint32_t count)
+{
+	_icao_ignore_start = start_address;
+	_icao_ignore_count = count;
+};
 
 bool AdsbConflict::send_traffic_warning(int traffic_direction, int traffic_seperation, uint16_t tr_flags,
 					char tr_callsign[UTM_CALLSIGN_LENGTH], uint32_t icao_address)

--- a/src/lib/adsb/AdsbConflict.h
+++ b/src/lib/adsb/AdsbConflict.h
@@ -111,6 +111,8 @@ public:
 
 	void add_icao_address_from_conflict_list(uint32_t icao_address);
 
+	void set_icao_ignore_range(uint32_t start_address, uint32_t count);
+
 	void get_traffic_state();
 
 	void set_conflict_detection_params(float crosstrack_separation, float vertical_separation,
@@ -157,4 +159,8 @@ private:
 	hrt_abstime _last_traffic_warning_time{0};
 
 	hrt_abstime _last_buffer_full_warning_time{0};
+
+	uint32_t _icao_ignore_start{0};
+
+	uint32_t _icao_ignore_count{0};
 };

--- a/src/lib/adsb/AdsbConflictTest.cpp
+++ b/src/lib/adsb/AdsbConflictTest.cpp
@@ -285,3 +285,71 @@ TEST_F(AdsbConflictTest, trafficReminder)
 	EXPECT_TRUE(adsb_conflict._traffic_state == TRAFFIC_STATE::ADD_CONFLICT);
 
 }
+
+TEST_F(AdsbConflictTest, trafficIgnoreIcaoAddress)
+{
+
+
+	// These are taken from detectTrafficConflict, ensuring that we find at least one conflict in the dataset
+	int collision_time_threshold = 60;
+	float crosstrack_separation = 500.0f;
+	float vertical_separation = 500.0f;
+	double lat_now = 32.617013;
+	double lon_now = -96.490564;
+	float alt_now = 1000.0f;
+	float vx_now = 0.0f;
+	float vy_now = 0.0f;
+	float vz_now = 0.0f;
+
+	uint32_t traffic_dataset_size = sizeof(traffic_dataset) / sizeof(traffic_dataset[0]);
+
+	struct traffic_data_s conflicting_traffic {0};
+	uint32_t traffic_idx = 0;
+
+	do {
+		conflicting_traffic = traffic_dataset[traffic_idx];
+	} while (++traffic_idx < traffic_dataset_size && !conflicting_traffic.in_conflict);
+
+	// This should never happen, unless there is a test bug or the dataset contains no conflicts
+	// But we check just in case, since the test is invalid if it's false
+	EXPECT_TRUE(conflicting_traffic.in_conflict);
+
+	TestAdsbConflict adsb_conflict;
+	adsb_conflict.set_conflict_detection_params(crosstrack_separation, vertical_separation, collision_time_threshold, 1);
+	adsb_conflict._transponder_report.lat = conflicting_traffic.lat_traffic;
+	adsb_conflict._transponder_report.lon = conflicting_traffic.lon_traffic;
+	adsb_conflict._transponder_report.altitude = conflicting_traffic.alt_traffic;
+	adsb_conflict._transponder_report.heading = conflicting_traffic.heading_traffic;
+	adsb_conflict._transponder_report.hor_velocity = conflicting_traffic.vxy_traffic;
+	adsb_conflict._transponder_report.ver_velocity = conflicting_traffic.vz_traffic;
+
+
+	adsb_conflict.set_icao_ignore_range(1, 3);
+
+	adsb_conflict._transponder_report.icao_address = 0;
+	adsb_conflict.detect_traffic_conflict(lat_now, lon_now, alt_now, vx_now, vy_now, vz_now);
+	EXPECT_TRUE(adsb_conflict._conflict_detected);
+
+	adsb_conflict._transponder_report.icao_address = 1;
+	adsb_conflict.detect_traffic_conflict(lat_now, lon_now, alt_now, vx_now, vy_now, vz_now);
+	EXPECT_FALSE(adsb_conflict._conflict_detected);
+
+	adsb_conflict._transponder_report.icao_address = 2;
+	adsb_conflict.detect_traffic_conflict(lat_now, lon_now, alt_now, vx_now, vy_now, vz_now);
+	EXPECT_FALSE(adsb_conflict._conflict_detected);
+
+	adsb_conflict._transponder_report.icao_address = 3;
+	adsb_conflict.detect_traffic_conflict(lat_now, lon_now, alt_now, vx_now, vy_now, vz_now);
+	EXPECT_FALSE(adsb_conflict._conflict_detected);
+
+	adsb_conflict._transponder_report.icao_address = 4;
+	adsb_conflict.detect_traffic_conflict(lat_now, lon_now, alt_now, vx_now, vy_now, vz_now);
+	EXPECT_TRUE(adsb_conflict._conflict_detected);
+
+	// Test special case with nonzero address but zero count. Should not ignore
+	adsb_conflict.set_icao_ignore_range(1, 0);
+
+	adsb_conflict._transponder_report.icao_address = 1;
+	adsb_conflict.detect_traffic_conflict(lat_now, lon_now, alt_now, vx_now, vy_now, vz_now);
+	EXPECT_TRUE(adsb_conflict._conflict_detected);
+}

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -408,6 +408,8 @@ private:
 		(ParamFloat<px4::params::MIS_YAW_TMT>)     _param_mis_yaw_tmt,
 		(ParamFloat<px4::params::MIS_YAW_ERR>)     _param_mis_yaw_err,
 		(ParamFloat<px4::params::MIS_PD_TO>)       _param_mis_payload_delivery_timeout,
-		(ParamInt<px4::params::MIS_LND_ABRT_ALT>)  _param_mis_lnd_abrt_alt
+		(ParamInt<px4::params::MIS_LND_ABRT_ALT>)  _param_mis_lnd_abrt_alt,
+		(ParamInt<px4::params::NAV_TRAFF_IGNADR>)  _param_nav_traff_ignadr,
+		(ParamInt<px4::params::NAV_TRAFF_IGNCNT>)  _param_nav_traff_igncnt
 	)
 };

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -144,6 +144,7 @@ void Navigator::params_update()
 	}
 
 	_mission.set_payload_deployment_timeout(_param_mis_payload_delivery_timeout.get());
+	_adsb_conflict.set_icao_ignore_range(_param_nav_traff_ignadr.get(), _param_nav_traff_igncnt.get());
 }
 
 void Navigator::run()

--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -187,3 +187,28 @@ PARAM_DEFINE_INT32(NAV_FORCE_VT, 1);
  * @group Mission
  */
 PARAM_DEFINE_FLOAT(NAV_MIN_LTR_ALT, -1.f);
+
+/**
+ * Ignore this ICAO address for traffic avoidance.
+ *
+ * Also ignore subsequent addresses if NAV_TRAFF_IGNCNT is greater than 1.
+ * Not used if NAV_TRAFF_IGNCNT is 0.
+ *
+ * @min 0
+ * @max 16777215
+ * @group Mission
+ */
+
+PARAM_DEFINE_INT32(NAV_TRAFF_IGNADR, 0);
+
+/**
+ * Ignore number of ICAO addresses to ignore for traffic avoidance.
+ *
+ * Starting with NAV_TRAFF_IGNADR. Set to 0 to disable.
+ *
+ * @min 0
+ * @max 16777215
+ * @group Mission
+ */
+
+PARAM_DEFINE_INT32(NAV_TRAFF_IGNCNT, 0);


### PR DESCRIPTION
For traffic avoidance, this adds the option to give a range of icao addresses that will not trigger the configured traffic avoidance action. Can be used to ignore an external transponder in the vehicle, or other vehicles in the same fleet.

This implements the same functionality for 1.15 as 9aa128d99dd7a81cb98a410e3bc91b2685eedd2c did for 1.13

Unit test passes, and sitl compiles with existing parameters, but I have not tested the functionality since I didn't have a traffic publisher available. I think we will see pretty quickly if this doesn't work once we start testing on hardware.