### PR TITLE
commander: add failure detection for MR vertical rate

### DIFF
--- a/msg/FailureDetectorStatus.msg
+++ b/msg/FailureDetectorStatus.msg
@@ -9,6 +9,7 @@ bool fd_arm_escs
 bool fd_battery
 bool fd_imbalanced_prop
 bool fd_motor
+bool fd_mpc_vz
 
 float32 imbalanced_prop_metric      # Metric of the imbalanced propeller check (low-passed)
 uint16 motor_failure_mask           # Bit-mask with motor indices, indicating critical motor failures

--- a/msg/VehicleStatus.msg
+++ b/msg/VehicleStatus.msg
@@ -80,6 +80,7 @@ uint16 FAILURE_ARM_ESC = 16          # (1 << 4)
 uint16 FAILURE_BATTERY = 32          # (1 << 5)
 uint16 FAILURE_IMBALANCED_PROP = 64  # (1 << 6)
 uint16 FAILURE_MOTOR = 128           # (1 << 7)
+uint16 FAILURE_MPC_VZ = 256          # (1 << 8)
 
 uint8 hil_state
 uint8 HIL_STATE_OFF = 0

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1926,6 +1926,7 @@ void Commander::run()
 			fd_status.fd_battery = _failure_detector.getStatusFlags().battery;
 			fd_status.fd_imbalanced_prop = _failure_detector.getStatusFlags().imbalanced_prop;
 			fd_status.fd_motor = _failure_detector.getStatusFlags().motor;
+			fd_status.fd_mpc_vz = _failure_detector.getStatusFlags().mpc_vz;
 			fd_status.imbalanced_prop_metric = _failure_detector.getImbalancedPropMetric();
 			fd_status.motor_failure_mask = _failure_detector.getMotorFailures();
 			fd_status.timestamp = hrt_absolute_time();

--- a/src/modules/commander/HealthAndArmingChecks/checks/failureDetectorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/failureDetectorCheck.cpp
@@ -94,9 +94,25 @@ void FailureDetectorChecks::checkAndReport(const Context &context, Report &repor
 		}
 	}
 
+
+	if (context.status().failure_detector_status & vehicle_status_s::FAILURE_MPC_VZ) {
+		/* EVENT
+		 * @description
+		 * <profile name="dev">
+		 * This check can be configured via <param>FD_MPC_VZ_THR</param> parameter.
+		 * </profile>
+		 */
+		reporter.armingCheckFailure(NavModes::All, health_component_t::system, events::ID("check_failure_detector_mpc_vz"),
+					    events::Log::Critical, "Multirotor vertical rate failure detected");
+
+		if (reporter.mavlink_log_pub()) {
+			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Multirotor vertical rate failure detected");
+		}
+	}
+
 	reporter.failsafeFlags().fd_critical_failure = context.status().failure_detector_status &
 			(vehicle_status_s::FAILURE_ROLL | vehicle_status_s::FAILURE_PITCH | vehicle_status_s::FAILURE_ALT |
-			 vehicle_status_s::FAILURE_EXT);
+			 vehicle_status_s::FAILURE_EXT | vehicle_status_s::FAILURE_MPC_VZ);
 
 
 	reporter.failsafeFlags().fd_esc_arming_failure = context.status().failure_detector_status &

--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -170,6 +170,13 @@ bool FailureDetector::update(const vehicle_status_s &vehicle_status, const vehic
 
 	failure_detector_status_u status_prev = _status;
 
+	if (vehicle_control_mode.flag_multicopter_position_control_enabled && _param_fd_mpc_vz_thr.get() > 0) {
+		updateMpcVzStatus();
+
+	} else {
+		_status.flags.mpc_vz = false;
+	}
+
 	if (vehicle_control_mode.flag_control_attitude_enabled) {
 		updateAttitudeStatus(vehicle_status);
 
@@ -470,5 +477,30 @@ void FailureDetector::updateMotorStatus(const vehicle_status_s &vehicle_status, 
 
 		_motor_failure_esc_under_current_mask = 0;
 		_status.flags.motor = false;
+	}
+}
+
+
+void FailureDetector::updateMpcVzStatus()
+{
+	vehicle_local_position_s position;
+	vehicle_local_position_setpoint_s position_sp;
+
+	if (_vehicle_local_position_sub.update(&position) &&
+	    _vehicle_local_position_setpoint_sub.copy(&position_sp)) {
+
+		const float max_z_velocity = _param_fd_mpc_vz_thr.get();
+
+		const bool is_descending_too_fast = position.v_z_valid && position.vz > max_z_velocity;
+		const bool is_trying_to_climb = PX4_ISFINITE(position_sp.vz) && position_sp.vz < -FLT_EPSILON;
+
+		const bool mpc_vz_status = is_trying_to_climb && is_descending_too_fast;
+
+		hrt_abstime time_now = hrt_absolute_time();
+
+		_mpc_vz_failure_hysteresis.set_hysteresis_time_from(false, (hrt_abstime)(1_s * _param_fd_mpc_vz_ttri.get()));
+		_mpc_vz_failure_hysteresis.set_state_and_update(mpc_vz_status, time_now);
+
+		_status.flags.mpc_vz = _mpc_vz_failure_hysteresis.get_state();
 	}
 }

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -60,7 +60,10 @@
 #include <uORB/topics/vehicle_command_ack.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_imu_status.h>
+#include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_local_position_setpoint.h>
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vtol_vehicle_status.h>
 #include <uORB/topics/esc_status.h>
 #include <uORB/topics/pwm_input.h>
 
@@ -74,6 +77,7 @@ union failure_detector_status_u {
 		uint16_t battery : 1;
 		uint16_t imbalanced_prop : 1;
 		uint16_t motor : 1;
+		uint16_t mpc_vz : 1;
 	} flags;
 	uint16_t value {0};
 };
@@ -111,6 +115,7 @@ private:
 	void updateExternalAtsStatus();
 	void updateEscsStatus(const vehicle_status_s &vehicle_status, const esc_status_s &esc_status);
 	void updateMotorStatus(const vehicle_status_s &vehicle_status, const esc_status_s &esc_status);
+	void updateMpcVzStatus();
 	void updateImbalancedPropStatus();
 
 	failure_detector_status_u _status{};
@@ -119,6 +124,7 @@ private:
 	systemlib::Hysteresis _pitch_failure_hysteresis{false};
 	systemlib::Hysteresis _ext_ats_failure_hysteresis{false};
 	systemlib::Hysteresis _esc_failure_hysteresis{false};
+	systemlib::Hysteresis _mpc_vz_failure_hysteresis{false};
 
 	static constexpr float _imbalanced_prop_lpf_time_constant{5.f};
 	AlphaFilter<float> _imbalanced_prop_lpf{};
@@ -138,6 +144,8 @@ private:
 	uORB::Subscription _sensor_selection_sub{ORB_ID(sensor_selection)};
 	uORB::Subscription _vehicle_imu_status_sub{ORB_ID(vehicle_imu_status)};
 	uORB::Subscription _actuator_motors_sub{ORB_ID(actuator_motors)};
+	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
+	uORB::Subscription _vehicle_local_position_setpoint_sub{ORB_ID(vehicle_local_position_setpoint)};
 
 	FailureInjector _failure_injector;
 
@@ -155,6 +163,8 @@ private:
 		(ParamBool<px4::params::FD_ACT_EN>) _param_fd_actuator_en,
 		(ParamFloat<px4::params::FD_ACT_MOT_THR>) _param_fd_motor_throttle_thres,
 		(ParamFloat<px4::params::FD_ACT_MOT_C2T>) _param_fd_motor_current2throttle_thres,
-		(ParamInt<px4::params::FD_ACT_MOT_TOUT>) _param_fd_motor_time_thres
+		(ParamInt<px4::params::FD_ACT_MOT_TOUT>) _param_fd_motor_time_thres,
+		(ParamInt<px4::params::FD_MPC_VZ_THR>) _param_fd_mpc_vz_thr,
+		(ParamFloat<px4::params::FD_MPC_VZ_TTRI>) _param_fd_mpc_vz_ttri
 	)
 };

--- a/src/modules/commander/failure_detector/failure_detector_params.c
+++ b/src/modules/commander/failure_detector/failure_detector_params.c
@@ -212,3 +212,32 @@ PARAM_DEFINE_FLOAT(FD_ACT_MOT_C2T, 2.0f);
  * @increment 100
  */
 PARAM_DEFINE_INT32(FD_ACT_MOT_TOUT, 100);
+
+/**
+ * Multicopter altitude rate fail threshold
+ *
+ * Maximum downwards vertical velocity before FailureDetector triggers the MR vertical_rate_failure flag.
+ * Will only be triggered if the setpoint is negative (ascending).
+ * Set to 0 to disable.
+ *
+ * @min 0
+ * @max 20
+ * @increment 1
+ * @group Failure Detector
+ */
+PARAM_DEFINE_INT32(FD_MPC_VZ_THR, 0);
+
+/**
+ * Multicopter altitude rate fail trigger time
+ *
+ * Seconds (decimal) that MR vertical rate has to exceed FD_MPC_VZ_THR before being considered as a failure.
+ *
+ * @unit s
+ * @min 0.02
+ * @max 5
+ * @decimal 2
+ *
+ * @group Failure Detector
+ */
+PARAM_DEFINE_FLOAT(FD_MPC_VZ_TTRI, 0.3);
+


### PR DESCRIPTION
A descent velocity above a configurable limit, while the rate setpoint is negative (ascending) will trigger failure detection.

This commit implements the same functionality for v1.15 as 7a6a79880eb00906dc06432730a53e35ffc750f2 did for v1.13

Tested that the event is triggered in SITL by reducing MPC_THR_MAX, but did not verify that the failure detector still triggers the parachute since we have no parachute in sitl yet.
<img width="2174" height="978" alt="image" src="https://github.com/user-attachments/assets/b061c504-036e-499b-93a4-7f4abec588d0" />