### PR TITLE
vtol_att_control: filter airspeed measurements in transition logic

### DIFF
--- a/msg/VtolVehicleStatus.msg
+++ b/msg/VtolVehicleStatus.msg
@@ -10,3 +10,6 @@ uint64 timestamp			# time since system start (microseconds)
 uint8 vehicle_vtol_state		# current state of the vtol, see VEHICLE_VTOL_STATE
 
 bool fixed_wing_system_failure		# vehicle in fixed-wing system failure failsafe mode (after quad-chute)
+
+float32 airspeed_filtered		# Filtered airspeed used during transition. NAN if invalid
+float32[4] mc_weights			# Multicopter blending weights for [roll, pitch, yaw, throttle]

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -104,8 +104,8 @@ void Standard::update_vtol_state()
 				const Vector3f vel = R_to_body * Vector3f(_local_pos->vx, _local_pos->vy, _local_pos->vz);
 				exit_backtransition_speed_condition = vel(0) < _param_mpc_xy_cruise.get();
 
-			} else if (PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s)) {
-				exit_backtransition_speed_condition = _airspeed_validated->calibrated_airspeed_m_s < _param_mpc_xy_cruise.get();
+			} else if (PX4_ISFINITE(_airspeed_filtered)) {
+				exit_backtransition_speed_condition = _airspeed_filtered < _param_mpc_xy_cruise.get();
 			}
 
 			const bool exit_backtransition_time_condition = _time_since_trans_start > _param_vt_b_trans_dur.get();
@@ -211,16 +211,16 @@ void Standard::update_transition_state()
 
 		// do blending of mc and fw controls if a blending airspeed has been provided and the minimum transition time has passed
 		if (_airspeed_trans_blend_margin > 0.0f &&
-		    PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s) &&
-		    _airspeed_validated->calibrated_airspeed_m_s > 0.0f &&
-		    _airspeed_validated->calibrated_airspeed_m_s >= getBlendAirspeed() &&
+		    PX4_ISFINITE(_airspeed_filtered) &&
+		    _airspeed_filtered > 0.0f &&
+		    _airspeed_filtered >= getBlendAirspeed() &&
 		    _time_since_trans_start > getMinimumFrontTransitionTime()) {
 
-			mc_weight = 1.0f - fabsf(_airspeed_validated->calibrated_airspeed_m_s - getBlendAirspeed()) /
+			mc_weight = 1.0f - fabsf(_airspeed_filtered - getBlendAirspeed()) /
 				    _airspeed_trans_blend_margin;
 			// time based blending when no airspeed sensor is set
 
-		} else if (!_param_fw_use_airspd.get() || !PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s)) {
+		} else if (!_param_fw_use_airspd.get() || !PX4_ISFINITE(_airspeed_filtered)) {
 			mc_weight = 1.0f - _time_since_trans_start / getMinimumFrontTransitionTime();
 			mc_weight = math::constrain(2.0f * mc_weight, 0.0f, 1.0f);
 

--- a/src/modules/vtol_att_control/standard_params.c
+++ b/src/modules/vtol_att_control/standard_params.c
@@ -79,6 +79,17 @@ PARAM_DEFINE_INT32(VT_FWD_THRUST_EN, 0);
 PARAM_DEFINE_FLOAT(VT_FWD_THRUST_SC, 0.7f);
 
 /**
+* Time constant for filtering airspeed measurements used during transition.
+*
+* @unit s
+* @decimal 1
+* @min 0.0
+* @max 5.0
+* @group VTOL Attitude Control
+*/
+PARAM_DEFINE_FLOAT(VT_ARSP_TAU, 1.0f);
+
+/**
  * Back transition MC motor ramp up time
  *
  * This sets the duration during which the MC motors ramp up to the commanded thrust during the back transition stage.

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -59,6 +59,8 @@ VtolAttitudeControl::VtolAttitudeControl() :
 	WorkItem(MODULE_NAME, px4::wq_configurations::rate_ctrl),
 	_loop_perf(perf_alloc(PC_ELAPSED, "vtol_att_control: cycle"))
 {
+	_airspeed_filter.reset(NAN);
+
 	// start vtol in rotary wing mode
 	_vtol_vehicle_status.vehicle_vtol_state = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC;
 
@@ -346,7 +348,11 @@ VtolAttitudeControl::Run()
 		_local_pos_sub.update(&_local_pos);
 		_local_pos_sp_sub.update(&_local_pos_sp);
 		_pos_sp_triplet_sub.update(&_pos_sp_triplet);
-		_airspeed_validated_sub.update(&_airspeed_validated);
+
+		if (_airspeed_validated_sub.update(&_airspeed_validated)) {
+			update_airspeed_filter(_airspeed_validated);
+		}
+
 		_tecs_status_sub.update(&_tecs_status);
 		_land_detected_sub.update(&_land_detected);
 
@@ -445,6 +451,11 @@ VtolAttitudeControl::Run()
 		// Advertise/Publish vtol vehicle status
 		_vtol_vehicle_status.timestamp = hrt_absolute_time();
 		_vtol_vehicle_status_pub.publish(_vtol_vehicle_status);
+		_vtol_vehicle_status.airspeed_filtered = get_filtered_airspeed();
+		_vtol_vehicle_status.mc_weights[0] = _vtol_type->get_mc_roll_weight();
+		_vtol_vehicle_status.mc_weights[1] = _vtol_type->get_mc_pitch_weight();
+		_vtol_vehicle_status.mc_weights[2] = _vtol_type->get_mc_yaw_weight();
+		_vtol_vehicle_status.mc_weights[3] = _vtol_type->get_mc_throttle_weight();
 
 		// Publish flaps/spoiler setpoint with configured deflection in Hover if in Auto.
 		// In Manual always published in FW rate controller, and in Auto FW in FW Position Controller.
@@ -473,6 +484,25 @@ VtolAttitudeControl::Run()
 	}
 
 	perf_end(_loop_perf);
+}
+
+void VtolAttitudeControl::update_airspeed_filter(const struct airspeed_validated_s &sample)
+{
+	if (!sample.airspeed_sensor_measurement_valid || !PX4_ISFINITE(sample.calibrated_airspeed_m_s)) {
+		_airspeed_filter.reset(NAN);
+	}
+
+	if (!PX4_ISFINITE(_airspeed_filter.getState())) {
+		_airspeed_filter.reset(sample.calibrated_airspeed_m_s);
+
+	} else {
+		// We must update the filter parameters, since we don't know the sensor sample rate
+		float dt_s = static_cast<float>(sample.timestamp - _airspeed_filter_last_timestamp) / 1e6f;
+		_airspeed_filter.setParameters(dt_s, _param_vt_arsp_tau.get());
+		_airspeed_filter.update(sample.calibrated_airspeed_m_s);
+	}
+
+	_airspeed_filter_last_timestamp = sample.timestamp;
 }
 
 int

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -53,6 +53,7 @@
 #include <lib/atmosphere/atmosphere.h>
 #include <lib/mathlib/mathlib.h>
 #include <lib/perf/perf_counter.h>
+#include <lib/mathlib/math/filter/AlphaFilter.hpp>
 #include <matrix/math.hpp>
 #include <px4_platform_common/px4_config.h>
 #include <px4_platform_common/defines.h>
@@ -128,6 +129,7 @@ public:
 	struct vehicle_thrust_setpoint_s		*get_vehicle_thrust_setpoint_virtual_fw() {return &_vehicle_thrust_setpoint_virtual_fw;}
 
 	struct airspeed_validated_s 			*get_airspeed() {return &_airspeed_validated;}
+	const float                    			&get_filtered_airspeed() { return _airspeed_filter.getState(); }
 	struct position_setpoint_triplet_s		*get_pos_sp_triplet() {return &_pos_sp_triplet;}
 	struct tecs_status_s 				*get_tecs_status() {return &_tecs_status;}
 	struct vehicle_attitude_s 			*get_att() {return &_vehicle_attitude;}
@@ -147,6 +149,8 @@ public:
 
 private:
 	void Run() override;
+	void update_airspeed_filter(const struct airspeed_validated_s &sample);
+
 	uORB::SubscriptionCallbackWorkItem _vehicle_torque_setpoint_virtual_fw_sub{this, ORB_ID(vehicle_torque_setpoint_virtual_fw)};
 	uORB::SubscriptionCallbackWorkItem _vehicle_torque_setpoint_virtual_mc_sub{this, ORB_ID(vehicle_torque_setpoint_virtual_mc)};
 	uORB::SubscriptionCallbackWorkItem _vehicle_thrust_setpoint_virtual_fw_sub{this, ORB_ID(vehicle_thrust_setpoint_virtual_fw)};
@@ -180,6 +184,9 @@ private:
 	uORB::Publication<vtol_vehicle_status_s>		_vtol_vehicle_status_pub{ORB_ID(vtol_vehicle_status)};
 
 	orb_advert_t	_mavlink_log_pub{nullptr};	// mavlink log uORB handle
+
+	AlphaFilter<float> _airspeed_filter;
+	hrt_abstime _airspeed_filter_last_timestamp{0};
 
 	vehicle_attitude_setpoint_s		_vehicle_attitude_sp{};	// vehicle attitude setpoint
 	vehicle_attitude_setpoint_s 		_fw_virtual_att_sp{};	// virtual fw attitude setpoint
@@ -238,6 +245,7 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::VT_TYPE>) _param_vt_type,
-		(ParamFloat<px4::params::VT_SPOILER_MC_LD>) _param_vt_spoiler_mc_ld
+		(ParamFloat<px4::params::VT_SPOILER_MC_LD>) _param_vt_spoiler_mc_ld,
+		(ParamFloat<px4::params::VT_ARSP_TAU>) _param_vt_arsp_tau
 	)
 };

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -60,7 +60,8 @@ static constexpr float kMaxWeightRatio = 2.0f;
 VtolType::VtolType(VtolAttitudeControl *att_controller) :
 	ModuleParams(nullptr),
 	_attc(att_controller),
-	_common_vtol_mode(mode::ROTARY_WING)
+	_common_vtol_mode(mode::ROTARY_WING),
+	_airspeed_filtered(_attc->get_filtered_airspeed())
 {
 	_v_att = _attc->get_att();
 	_v_att_sp = _attc->get_att_sp();
@@ -207,7 +208,7 @@ bool VtolType::isFrontTransitionCompleted()
 bool VtolType::isFrontTransitionCompletedBase()
 {
 	// continue the transition to fw mode while monitoring airspeed for a final switch to fw mode
-	const bool airspeed_triggers_transition = PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s)
+	const bool airspeed_triggers_transition = PX4_ISFINITE(_airspeed_filtered)
 			&& _param_fw_use_airspd.get();
 	const bool minimum_trans_time_elapsed = _time_since_trans_start > getMinimumFrontTransitionTime();
 	const bool openloop_trans_time_elapsed = _time_since_trans_start > getOpenLoopFrontTransitionTime();
@@ -216,7 +217,7 @@ bool VtolType::isFrontTransitionCompletedBase()
 
 	if (airspeed_triggers_transition) {
 		transition_to_fw = minimum_trans_time_elapsed
-				   && _airspeed_validated->calibrated_airspeed_m_s >= getTransitionAirspeed();
+				   && _airspeed_filtered >= getTransitionAirspeed();
 
 	} else {
 		transition_to_fw = openloop_trans_time_elapsed;

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -214,6 +214,14 @@ public:
 	bool can_transition_on_ground();
 
 	/**
+	 * Get the weights for multicopter attitude control output
+	 */
+	float get_mc_roll_weight() const { return _mc_roll_weight; }
+	float get_mc_pitch_weight() const { return _mc_pitch_weight; }
+	float get_mc_yaw_weight() const { return _mc_yaw_weight; }
+	float get_mc_throttle_weight() const { return _mc_throttle_weight; }
+
+	/**
 	 * Pusher assist in hover (pusher/pull for standard VTOL, motor tilt for tiltrotor)
 	 */
 	float pusher_assist();
@@ -283,6 +291,7 @@ protected:
 	struct vehicle_local_position_s			*_local_pos;
 	struct vehicle_local_position_setpoint_s	*_local_pos_sp;
 	struct airspeed_validated_s 			*_airspeed_validated;					// airspeed
+	const float		    			&_airspeed_filtered;					// filtered airspeed
 	struct tecs_status_s				*_tecs_status;
 	struct vehicle_land_detected_s			*_land_detected;
 


### PR DESCRIPTION
Based on https://github.com/aviant-tech/PX4-Autopilot/pull/56, ported to 1.15.

I use a reference to the `AlphaFilter` state, and set it to NAN instead of having a separate getter and `valid` variable. This reduces code complexity.

Also, since `_mc_{roll, pitch, yaw, thrust}_weight` is now protected, I had to add some getters. We could potentially drop those fields from the message, but I think they are nice for debugging. 