### PR TITLE
commander: add minimum alt agl for failure detector flight termination

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -44,6 +44,7 @@
 #include "Arming/ArmAuthorization/ArmAuthorization.h"
 #include "commander_helper.h"
 #include "esc_calibration.h"
+#include "uORB/topics/vehicle_local_position.h"
 #define DEFINE_GET_PX4_CUSTOM_MODE
 #include "px4_custom_mode.h"
 #include "ModeUtil/control_mode.hpp"
@@ -1792,6 +1793,8 @@ void Commander::run()
 		/* Update OA parameter */
 		_vehicle_status.avoidance_system_required = _param_com_obs_avoid.get();
 
+		updateAltAglTooLowForFdFlightterm();
+
 		handlePowerButtonState();
 
 		systemPowerUpdate();
@@ -2045,6 +2048,37 @@ bool Commander::getPrearmState() const
 	}
 
 	return false;
+}
+
+void Commander::updateAltAglTooLowForFdFlightterm()
+{
+
+	const float min_alt_agl_for_fd_flightterm = _param_com_fdtrm_minagl.get();
+
+	if (min_alt_agl_for_fd_flightterm < FLT_EPSILON) {
+		// The feature is disabled
+		_alt_agl_too_low_for_fd_flightterm = false;
+		return;
+	}
+
+	vehicle_local_position_s position;
+
+	if (_vehicle_local_position_sub.copy(&position)) {
+		if (
+			position.dist_bottom_valid &&
+			position.dist_bottom < min_alt_agl_for_fd_flightterm
+		) {
+			_alt_agl_too_low_for_fd_flightterm = true;
+
+		} else {
+			_alt_agl_too_low_for_fd_flightterm = false;
+		}
+
+	} else {
+		// reset to false if we can't get local position
+		// so we don't get stuck blocking termination
+		_alt_agl_too_low_for_fd_flightterm = false;
+	}
 }
 
 void Commander::handlePowerButtonState()
@@ -2313,6 +2347,7 @@ bool Commander::handleModeIntentionAndFailsafe()
 	state.mission_finished = _mission_result_sub.get().finished;
 	state.user_intended_mode = _user_mode_intention.get();
 	state.vehicle_type = _vehicle_status.vehicle_type;
+	state.alt_agl_too_low_for_fd_flightterm = _alt_agl_too_low_for_fd_flightterm;
 
 	// There might have been a mode change request without changing the user intended mode.
 	// If a failsafe is active we must pass the request along as it might lead to a user-takeover.

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -168,6 +168,8 @@ private:
 
 	void checkForMissionUpdate();
 
+	void updateAltAglTooLowForFdFlightterm();
+
 	void handlePowerButtonState();
 
 	void systemPowerUpdate();
@@ -279,6 +281,8 @@ private:
 	bool _have_taken_off_since_arming{false};
 	bool _status_changed{true};
 
+	bool _alt_agl_too_low_for_fd_flightterm{false};
+
 	vehicle_land_detected_s	_vehicle_land_detected{};
 
 	// commander publications
@@ -296,6 +300,7 @@ private:
 	uORB::Subscription					_vehicle_command_mode_executor_sub{ORB_ID(vehicle_command_mode_executor)};
 	uORB::Subscription					_vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
 	uORB::Subscription					_vtol_vehicle_status_sub{ORB_ID(vtol_vehicle_status)};
+	uORB::Subscription					_vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 
 	uORB::SubscriptionInterval				_parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
@@ -347,6 +352,7 @@ private:
 		(ParamInt<px4::params::COM_RC_OVERRIDE>)    _param_com_rc_override,
 		(ParamInt<px4::params::COM_FLIGHT_UUID>)    _param_flight_uuid,
 		(ParamInt<px4::params::COM_TAKEOFF_ACT>)    _param_takeoff_finished_action,
-		(ParamFloat<px4::params::COM_CPU_MAX>)      _param_com_cpu_max
+		(ParamFloat<px4::params::COM_CPU_MAX>)      _param_com_cpu_max,
+		(ParamFloat<px4::params::COM_FDTRM_MINAGL>) _param_com_fdtrm_minagl
 	)
 };

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1044,3 +1044,21 @@ PARAM_DEFINE_FLOAT(COM_THROW_SPEED, 5);
  * @increment 1
  */
 PARAM_DEFINE_INT32(COM_FLTT_LOW_ACT, 3);
+
+/**
+ * Minimum Ground Distance For Failure Detector Termination
+ *
+ * The value has implications for determining whether the
+ * failure detector can trigger flight termination.
+ * If a failure is detected and the vehicle's distance from the ground is less than this value,
+ * commander will not execute flight termination even if CBRK_FLIGHTTERM allows it.
+ * This is intended to avoid termination below the minimum parachute deployment altitude,
+ * where the parachute would not have time to deploy properly.
+ *
+ * @decimal 2
+ * @min 0.00
+ * @max 10000.00
+ * @unit m
+ * @group Commander
+ */
+PARAM_DEFINE_FLOAT(COM_FDTRM_MINAGL, 0.00);

--- a/src/modules/commander/failsafe/emscripten.cpp
+++ b/src/modules/commander/failsafe/emscripten.cpp
@@ -167,6 +167,7 @@ void set_param_value_float(const std::string &name, float value)
 
 int failsafe_update(bool armed, bool vtol_in_transition_mode, bool mission_finished,
 		    bool user_override, uint8_t user_intended_mode, uint8_t vehicle_type,
+		    bool alt_too_low_for_fd_flightterm,
 		    failsafe_flags_s status_flags, bool defer_failsafes)
 {
 	uint64_t time_ms = emscripten_date_now();
@@ -176,6 +177,7 @@ int failsafe_update(bool armed, bool vtol_in_transition_mode, bool mission_finis
 	state.mission_finished = mission_finished;
 	state.user_intended_mode = user_intended_mode;
 	state.vehicle_type = vehicle_type;
+	state.alt_agl_too_low_for_fd_flightterm = alt_too_low_for_fd_flightterm;
 	mode_util::getModeRequirements(vehicle_type, status_flags);
 	failsafe_instance.current().deferFailsafes(defer_failsafes, 0);
 	return failsafe_instance.current().update(time_ms * 1000, state, false, user_override, status_flags);

--- a/src/modules/commander/failsafe/emscripten_template.html
+++ b/src/modules/commander/failsafe/emscripten_template.html
@@ -180,6 +180,11 @@
                             <td></td>
                         </tr>
                         <tr>
+                            <td><label for="alt_agl_too_low_for_fd_flightterm">Altitude too low for Failure Detector Flight Termination</label></td>
+                            <td><input type="checkbox" id="alt_agl_too_low_for_fd_flightterm" name="alt_agl_too_low_for_fd_flightterm"></td>
+                            <td></td>
+                        </tr>
+                        <tr>
                             <td><label for="intended_nav_state">Intended Mode:&nbsp;</label></td>
                             <td><select id="intended_nav_state">
                                 <option value="0">MANUAL</option>
@@ -325,11 +330,21 @@
           var armed = document.querySelector('input[id="armed"]').checked;
           var vtol_in_transition_mode = document.querySelector('input[id="vtol_in_transition_mode"]').checked;
           var mission_finished = document.querySelector('input[id="mission_finished"]').checked;
+          var alt_agl_too_low_for_fd_flightterm = document.querySelector('input[id="alt_agl_too_low_for_fd_flightterm"]').checked;
           var intended_nav_state = document.querySelector('select[id="intended_nav_state"]').value;
           var vehicle_type = document.querySelector('select[id="vehicle_type"]').value;
           var defer_failsafes = document.querySelector('input[id="defer_failsafes"]').checked;
-          var updated_user_intended_mode = Module.failsafe_update(armed, vtol_in_transition_mode, mission_finished, user_override_requested, parseInt(intended_nav_state),
-              parseInt(vehicle_type), state, defer_failsafes);
+          var updated_user_intended_mode = Module.failsafe_update(
+              armed,
+              vtol_in_transition_mode,
+              mission_finished,
+              user_override_requested,
+              parseInt(intended_nav_state),
+              parseInt(vehicle_type),
+              alt_agl_too_low_for_fd_flightterm,
+              state,
+              defer_failsafes,
+          );
           user_override_requested = false;
           var action = Module.selected_action();
           action_str = Module.action_str(action);

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -526,10 +526,14 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 		// This handles the case where something fails during the early takeoff phase
 		CHECK_FAILSAFE(status_flags, fd_critical_failure, ActionOptions(Action::Disarm).cannotBeDeferred());
 
-	} else if (!circuit_breaker_enabled_by_val(_param_cbrk_flightterm.get(), CBRK_FLIGHTTERM_KEY)) {
+	} else if (
+		!circuit_breaker_enabled_by_val(_param_cbrk_flightterm.get(), CBRK_FLIGHTTERM_KEY)
+		&& !state.alt_agl_too_low_for_fd_flightterm
+	) {
 		CHECK_FAILSAFE(status_flags, fd_critical_failure, ActionOptions(Action::Terminate).cannotBeDeferred());
 
 	} else {
+		// TODO: Consider doing another action, e.g. Land
 		CHECK_FAILSAFE(status_flags, fd_critical_failure, Action::Warn);
 	}
 

--- a/src/modules/commander/failsafe/framework.h
+++ b/src/modules/commander/failsafe/framework.h
@@ -129,6 +129,7 @@ public:
 		uint8_t vehicle_type;
 		bool vtol_in_transition_mode{false};
 		bool mission_finished{false};
+		bool alt_agl_too_low_for_fd_flightterm{false};
 	};
 
 	FailsafeBase(ModuleParams *parent);


### PR DESCRIPTION
This commit implements the same functionality for v1.15 as d65a4945adcb4793f3adf4762d09ef9152f9e6c2 did for v1.13

However, the functionality is moved out of the failure detector and into commander. Therefore, the parameter is also renamed and moved to the commander group.

Tested using the failsafe state machine simulator webpage and in sitl using the vertical rate failure detector.
