### PR TITLE
mixer_module: dynamically set max actuator value based on battery

### DIFF
--- a/Tools/module_config/generate_actuators_metadata.py
+++ b/Tools/module_config/generate_actuators_metadata.py
@@ -153,6 +153,9 @@ def get_actuator_output(yaml_config, output_functions, timer_config_file, verbos
             param = {
                     'name': config_param['param'],
                 }
+            if 'param_prefix' in config_param:
+                param_prefix = process_param_prefix(config_param['param_prefix'])
+                param['name'] = param_prefix + '_' + config_param['param']
             if 'label' in config_param:
                 param['label'] = config_param['label']
             if 'function' in config_param:
@@ -264,6 +267,12 @@ def get_actuator_output(yaml_config, output_functions, timer_config_file, verbos
             }
         per_channel_params.append(param)
 
+        per_channel_params.append({
+                'label': 'Dynalim',
+                'name': param_prefix+'_DCHNS',
+                'index-offset': -1,
+                'show-as': 'bitset',
+        })
         custom_params = group.get('custom_params', [])
         for custom_param in custom_params:
             # Simply pulls all custom params, assuming they are valid ones

--- a/Tools/module_config/generate_params.py
+++ b/Tools/module_config/generate_params.py
@@ -351,6 +351,41 @@ Note: this is only useful for servos.
             }
         add_local_param(param_prefix+'_REV', param)
 
+        param = {
+            'description': {
+                'short': f'Outputs with dynamic max limiting for {param_prefix}',
+                'long':
+f'''
+The selected outputs will reduce the max output
+based on {param_prefix}_DRNG and the dynamic allocator
+signal received from the battery module.
+'''
+            },
+            'type': 'bitmask',
+            'default': 0,
+            'bit': channel_bits
+        }
+        add_local_param(param_prefix+'_DCHNS', param)
+
+        param = {
+            'description': {
+                'short': f'Amount to reduce max limit, given a full battery for {param_prefix} outputs',
+                'long':
+f'''
+The outputs given by {param_prefix}_DCHNS will have a reduction
+in output range (max-min) given by this scalar when the
+battery is full. The output will gradually be scaled up
+as the battery is drained.
+'''
+            },
+            'type': 'float',
+            'min': 0,
+            'max': 1,
+            'decimal': 2,
+            'default': 0
+        }
+        add_local_param(param_prefix+'_DRNG', param)
+
     if verbose: print('adding actuator params: {:}'.format(all_params))
     return all_params
 

--- a/msg/BatteryStatus.msg
+++ b/msg/BatteryStatus.msg
@@ -8,6 +8,7 @@ float32 current_average_a	# Battery current average in amperes (for FW average i
 float32 discharged_mah		# Discharged amount in mAh, -1 if unknown
 float32 remaining			# From 1 to 0, -1 if unknown
 float32 scale				# Power scaling factor, >= 1, or -1 if unknown
+float32 dynamic_actuator	# From 0 to 1, how much of actuator output dynamic range to allow, -1 for failure to calculate
 float32 time_remaining_s	# predicted time in seconds remaining until battery is empty under previous averaged load, NAN if unknown
 float32 temperature			# temperature of the battery. NaN if unknown
 uint8 cell_count			# Number of cells, 0 if unknown

--- a/src/drivers/pwm_out/module.yaml
+++ b/src/drivers/pwm_out/module.yaml
@@ -1,5 +1,9 @@
 module_name: '${PWM_MAIN_OR_AUX}'
 actuator_output:
+  config_parameters:
+        - param: 'DRNG'
+          param_prefix: '${PWM_MAIN_OR_AUX}'
+          label: 'Dynamic Range'
   output_groups:
     - generator: pwm
       param_prefix: '${PWM_MAIN_OR_AUX}'

--- a/src/drivers/px4io/module.yaml
+++ b/src/drivers/px4io/module.yaml
@@ -1,5 +1,8 @@
 module_name: PWM MAIN
 actuator_output:
+  config_parameters:
+        - param: 'PWM_MAIN_DRNG'
+          label: 'Dynamic Range'
   output_groups:
     - generator: pwm
       param_prefix: PWM_MAIN

--- a/src/drivers/uavcan/module.yaml
+++ b/src/drivers/uavcan/module.yaml
@@ -16,6 +16,9 @@ actuator_output:
         max: { min: 0, max: 8191, default: 8191 }
         failsafe: { min: 0, max: 8191 }
       num_channels: 8
+      config_parameters:
+        - param: 'UAVCAN_EC_DRNG'
+          label: 'Dynamic Range'
     - param_prefix: UAVCAN_SV
       group_label: 'Servos'
       channel_label: 'Servo'
@@ -25,3 +28,6 @@ actuator_output:
         max: { min: 0, max: 1000, default: 1000 }
         failsafe: { min: 0, max: 1000 }
       num_channels: 8
+      config_parameters:
+        - param: 'UAVCAN_SV_DRNG'
+          label: 'Dynamic Range'

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -90,6 +90,12 @@ Battery::Battery(int index, ModuleParams *parent, const int sample_interval_us, 
 	snprintf(param_name, sizeof(param_name), "BAT%d_SOURCE", _index);
 	_param_handles.source = param_find(param_name);
 
+	snprintf(param_name, sizeof(param_name), "BAT%d_DYNACT", _index);
+	_param_handles.dynact = param_find(param_name);
+
+	snprintf(param_name, sizeof(param_name), "BAT%d_Q_MAXACT", _index);
+	_param_handles.q_maxact = param_find(param_name);
+
 	_param_handles.low_thr = param_find("BAT_LOW_THR");
 	_param_handles.crit_thr = param_find("BAT_CRIT_THR");
 	_param_handles.emergen_thr = param_find("BAT_EMERGEN_THR");
@@ -144,6 +150,7 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp)
 	}
 
 	computeScale();
+	computeDynamicActuator();
 
 	if (_connected && _battery_initialized) {
 		_warning = determineWarning(_state_of_charge);
@@ -161,6 +168,7 @@ battery_status_s Battery::getBatteryStatus()
 	battery_status.discharged_mah = _discharged_mah;
 	battery_status.remaining = _state_of_charge;
 	battery_status.scale = _scale;
+	battery_status.dynamic_actuator = _dynamic_actuator;
 	battery_status.time_remaining_s = computeRemainingTime(_current_a);
 	battery_status.temperature = _temperature_c;
 	battery_status.cell_count = _params.n_cells;
@@ -307,6 +315,47 @@ void Battery::computeScale()
 	}
 }
 
+void Battery::computeDynamicActuator()
+{
+	// Check if the battery is full, based on voltage alone,
+	// and latch the status if it is.
+	if (!_battery_was_full) {
+		float min_voltage = _params.n_cells * _params.v_charged * 0.97f;  // Hard code 3% acceptance range
+		float max_voltage = _params.n_cells * _params.v_charged * 1.2f;   // Sanity check
+		float voltage = _voltage_filter_v.getState();
+
+		if (voltage < max_voltage && voltage > min_voltage) { _battery_was_full = true; }
+	}
+
+	switch (_params.dynact) {
+	case -1:  // Disabled - dynamic range always disabled
+		_dynamic_actuator = 0.f;
+		break;
+
+	case 0:  // Disabled - dynamic range always enabled
+		_dynamic_actuator = 1.f;
+		break;
+
+	case 1:  // Consumption based - require full battery
+		if (!_battery_was_full) {
+			_dynamic_actuator = -1.f;
+
+		} else {
+			_dynamic_actuator = math::interpolate(_discharged_mah, 0.f, _params.q_maxact, 0.f, 1.f);
+		}
+
+		break;
+
+	case 2:  // Consumption based - do not require full battery
+		_dynamic_actuator = math::interpolate(_discharged_mah, 0.f, _params.q_maxact, 0.f, 1.f);
+		break;
+
+	default:
+		// Set to error value if unknown mode
+		_dynamic_actuator = -1.f;
+	}
+}
+
 float Battery::computeRemainingTime(float current_a)
 {
 	float time_remaining_s = NAN;
@@ -354,6 +403,8 @@ void Battery::updateParams()
 	param_get(_param_handles.v_load_drop, &_params.v_load_drop);
 	param_get(_param_handles.r_internal, &_params.r_internal);
 	param_get(_param_handles.source, &_params.source);
+	param_get(_param_handles.dynact, &_params.dynact);
+	param_get(_param_handles.q_maxact, &_params.q_maxact);
 	param_get(_param_handles.low_thr, &_params.low_thr);
 	param_get(_param_handles.crit_thr, &_params.crit_thr);
 	param_get(_param_handles.emergen_thr, &_params.emergen_thr);

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -126,6 +126,8 @@ protected:
 		param_t emergen_thr;
 		param_t source;
 		param_t bat_avrg_current;
+		param_t dynact;
+		param_t q_maxact;
 	} _param_handles{};
 
 	struct {
@@ -140,6 +142,8 @@ protected:
 		float emergen_thr;
 		int32_t source;
 		float bat_avrg_current;
+		int32_t dynact;
+		float q_maxact;
 	} _params{};
 
 	const int _index;
@@ -154,6 +158,7 @@ private:
 	uint8_t determineWarning(float state_of_charge);
 	uint16_t determineFaults();
 	void computeScale();
+	void computeDynamicActuator();
 	float computeRemainingTime(float current_a);
 
 	uORB::Subscription _vehicle_thrust_setpoint_0_sub{ORB_ID(vehicle_thrust_setpoint)};
@@ -180,6 +185,8 @@ private:
 	float _state_of_charge{-1.f}; // [0,1]
 	float _scale{1.f};
 	float _temperature_c{NAN};
+	float _dynamic_actuator{-1.f};
+	bool _battery_was_full{false};
 	uint8_t _warning{battery_status_s::BATTERY_WARNING_NONE};
 	hrt_abstime _last_timestamp{0};
 	bool _armed{false};

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -143,3 +143,36 @@ parameters:
             num_instances: *max_num_config_instances
             instance_start: 1
             default: [0, -1, -1]
+
+        BAT${i}_Q_MAXACT:
+            description:
+                short: Battery ${i} consumption limit for scaling dynamic actuator output.
+                long: |
+                    Defines a battery consumption limit for battery ${i} in mAh, after which
+                    the full dynamic actuator limit will be used. Below this limit,
+                    the dynamic range is linearly unlocked according to consumption.
+                    Set BAT${i}_DYNACT to "Consumption based" to use.
+            type: float
+            unit: mAh
+            min: 0.0
+            max: 100000
+            decimal: 0
+            increment: 50
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: [0.0, 0.0, 0.0]
+
+        BAT${i}_DYNACT:
+            description:
+                short: Dynamic actuator range mode for battery ${i}.
+                long: |
+                    Select the dynamic acruator range mode for the battery.
+            type: enum
+            values:
+                -1: Disabled - dynamic range always disabled
+                0: Disabled - dynamic range always enabled
+                1: Consumption based - require full battery
+                2: Consumption based - do not require full battery
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: [0, 0, 0]

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -127,6 +127,11 @@ void MixingOutput::initParamHandles()
 
 	snprintf(param_name, sizeof(param_name), "%s_%s", _param_prefix, "REV");
 	_param_handle_rev_range = param_find(param_name);
+	// Dynamic actuator limiting based on battery
+	snprintf(param_name, sizeof(param_name), "%s_%s", _param_prefix, "DRNG");
+	_param_handle_dynamic_range = param_find(param_name);
+	snprintf(param_name, sizeof(param_name), "%s_%s", _param_prefix, "DCHNS");
+	_param_handle_dynamic_channels = param_find(param_name);
 }
 
 void MixingOutput::printStatus() const
@@ -141,9 +146,10 @@ void MixingOutput::printStatus() const
 	PX4_INFO_RAW("Channel Configuration:\n");
 
 	for (unsigned i = 0; i < _max_num_outputs; i++) {
-		PX4_INFO_RAW("Channel %i: func: %3i, value: %i, failsafe: %d, disarmed: %d, min: %d, max: %d\n", i,
+		PX4_INFO_RAW("Channel %i: func: %3i, value: %i, failsafe: %d, disarmed: %d, min: %d, max: %d/%d, dynalim: %s\n", i,
 			     (int)_function_assignment[i], _current_output_value[i],
-			     actualFailsafeValue(i), _disarmed_value[i], _min_value[i], _max_value[i]);
+			     actualFailsafeValue(i), _disarmed_value[i], _min_value[i], _dynamic_max_value[i], _max_value[i],
+			     _dynamic_channels & (1 << i) ? "true" : "false");
 	}
 }
 
@@ -193,6 +199,18 @@ void MixingOutput::updateParams()
 	if (_param_handle_rev_range != PARAM_INVALID && param_get(_param_handle_rev_range, &rev_range_param) == 0) {
 		_reverse_output_mask = rev_range_param;
 	}
+
+	// Dynamic output limiting based on battery
+	if (_param_handle_dynamic_channels == PARAM_INVALID
+	    || param_get(_param_handle_dynamic_channels, &_dynamic_channels) != 0) {
+		_dynamic_channels = 0;
+	}
+
+	if (_param_handle_dynamic_range == PARAM_INVALID || param_get(_param_handle_dynamic_range, &_dynamic_range) != 0) {
+		_dynamic_range = 0.f;
+	}
+
+	_dynamic_range = math::constrain(_dynamic_range, 0.f, 1.f);
 
 	if (function_changed) {
 		_need_function_update = true;
@@ -455,6 +473,27 @@ bool MixingOutput::update()
 		}
 	}
 
+	// Update dynamic max limit
+	battery_status_s battery_status;
+
+	if (_battery_sub.update(&battery_status)) {
+		// Constrain to sane values, this also interprets the error/disabled value "-1" as 0
+		_dynamic_actuator = math::constrain(battery_status.dynamic_actuator, 0.f, 1.f);
+	}
+
+	float dynamic_limit = math::interpolate(_dynamic_actuator, 0.f, 1.f, _dynamic_range, 0.f);
+
+	for (unsigned i = 0; i < MAX_ACTUATORS; i++) {
+		if (_dynamic_channels & (1 << i)) {
+			uint16_t dynamic_max = _max_value[i] - uint16_t(float(_max_value[i] - _min_value[i]) * dynamic_limit);
+			dynamic_max = math::max(_min_value[i], dynamic_max);
+			_dynamic_max_value[i] = dynamic_max;
+
+		} else {
+			_dynamic_max_value[i] = _max_value[i];
+		}
+	}
+
 	// Send output if any function mapped or one last disabling sample
 	if (!all_disabled || !_was_all_disabled) {
 		if (!_armed.armed && !_armed.manual_lockdown) {
@@ -532,7 +571,7 @@ uint16_t MixingOutput::output_limit_calc_single(int i, float value) const
 	}
 
 	const float output = math::interpolate(value, -1.f, 1.f,
-					       static_cast<float>(_min_value[i]), static_cast<float>(_max_value[i]));
+					       static_cast<float>(_min_value[i]), static_cast<float>(_dynamic_max_value[i]));
 
 	return math::constrain(lroundf(output), 0L, static_cast<long>(UINT16_MAX));
 }

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -58,6 +58,7 @@
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/actuator_outputs.h>
+#include <uORB/topics/battery_status.h>
 #include <uORB/topics/parameter_update.h>
 
 using namespace time_literals;
@@ -233,6 +234,7 @@ private:
 		param_t min{PARAM_INVALID};
 		param_t max{PARAM_INVALID};
 		param_t failsafe{PARAM_INVALID};
+		param_t dynamic_range{PARAM_INVALID};
 	};
 
 	void lock() { do {} while (px4_sem_wait(&_lock) != 0); }
@@ -244,6 +246,7 @@ private:
 	uint16_t _disarmed_value[MAX_ACTUATORS] {};
 	uint16_t _min_value[MAX_ACTUATORS] {};
 	uint16_t _max_value[MAX_ACTUATORS] {};
+	uint16_t _dynamic_max_value[MAX_ACTUATORS] {};
 	uint16_t _current_output_value[MAX_ACTUATORS] {}; ///< current output values (reordered)
 	uint16_t _reverse_output_mask{0}; ///< reverses the interval [min, max] -> [max, min], NOT motor direction
 
@@ -257,6 +260,8 @@ private:
 	const bool _output_ramp_up; ///< if true, motors will ramp up from disarmed to min_output after arming
 
 	uORB::Subscription _armed_sub{ORB_ID(actuator_armed)};
+	// Only subscribe to the first battery instance
+	uORB::Subscription _battery_sub{ORB_ID(battery_status)};
 
 	uORB::PublicationMulti<actuator_outputs_s> _outputs_pub{ORB_ID(actuator_outputs)};
 
@@ -285,6 +290,11 @@ private:
 	const char *const _param_prefix;
 	ParamHandles _param_handles[MAX_ACTUATORS];
 	param_t _param_handle_rev_range{PARAM_INVALID};
+	param_t _param_handle_dynamic_range{PARAM_INVALID};
+	param_t _param_handle_dynamic_channels{PARAM_INVALID};
+	float _dynamic_actuator = 0.f;  // from battery subscription. Init to 0 assumes full battery until data is received.
+	float _dynamic_range = 0.f;
+	int32_t _dynamic_channels = 0;
 	hrt_abstime _lowrate_schedule_interval{300_ms};
 	ActuatorTest _actuator_test{_function_assignment};
 	uint32_t _reversible_mask{0}; ///< per-output bits. If set, the output is configured to be reversible (motors only)

--- a/src/lib/mixer_module/mixer_module_tests.cpp
+++ b/src/lib/mixer_module/mixer_module_tests.cpp
@@ -488,6 +488,7 @@ TEST_F(MixerModuleTest, OutputLimitCalcSingle)
 
 	mixing_output.setAllMinValues(MIN_VALUE); // default range [1000,2000]
 	mixing_output.setAllMaxValues(MAX_VALUE);
+	mixing_output.update(); // Needed for recalculating dynamic range
 	EXPECT_EQ(mixing_output.output_limit_calc_single(0, -1.f), 1000); // In range
 	EXPECT_EQ(mixing_output.output_limit_calc_single(0, -.5f), 1250);
 	EXPECT_EQ(mixing_output.output_limit_calc_single(0, 0.f), 1500);
@@ -503,6 +504,7 @@ TEST_F(MixerModuleTest, OutputLimitCalcSingle)
 
 	mixing_output.setAllMinValues(0); // lower range [0,20]
 	mixing_output.setAllMaxValues(20);
+	mixing_output.update(); // Needed for recalculating dynamic range
 	EXPECT_EQ(mixing_output.output_limit_calc_single(0, -1.f), 0); // In range
 	EXPECT_EQ(mixing_output.output_limit_calc_single(0, -.5f), 5);
 	EXPECT_EQ(mixing_output.output_limit_calc_single(0, 0.f), 10);
@@ -518,6 +520,7 @@ TEST_F(MixerModuleTest, OutputLimitCalcSingle)
 
 	mixing_output.setAllMinValues(20); // inverted range [20,0]
 	mixing_output.setAllMaxValues(0);
+	mixing_output.update(); // Needed for recalculating dynamic range
 	EXPECT_EQ(mixing_output.output_limit_calc_single(0, -1.f), 20); // In range
 	EXPECT_EQ(mixing_output.output_limit_calc_single(0, -.5f), 15);
 	EXPECT_EQ(mixing_output.output_limit_calc_single(0, 0.f), 10);

--- a/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
@@ -146,6 +146,26 @@ void BatteryChecks::checkAndReport(const Context &context, Report &reporter)
 							     battery_mode_str(static_cast<battery_mode_t>(battery.mode)));
 				}
 			}
+
+		} else {
+			const bool dynalim_fail = battery.dynamic_actuator < 0;
+
+			if (dynalim_fail) {
+				/* EVENT
+				 * @description
+				 * <profile name="dev">
+				 * Dynalim settings for this battery can be configured using BAT{1}_DYNACT parameter
+				 * </profile>
+				 */
+				reporter.armingCheckFailure<uint8_t>(NavModes::All, health_component_t::battery,
+								     events::ID("check_battery_dynalim_fail"),
+								     events::Log::Critical, "Battery {1}: Dynalim error. A fully charged battery may be required", index + 1);
+
+				if (reporter.mavlink_log_pub()) {
+					mavlink_log_critical(reporter.mavlink_log_pub(), "Battery %d: Dynalim error. A fully charged battery may be required\t",
+							     index + 1);
+				}
+			}
 		}
 
 		if (battery.connected) {

--- a/src/modules/simulation/pwm_out_sim/module_hil.yaml
+++ b/src/modules/simulation/pwm_out_sim/module_hil.yaml
@@ -1,6 +1,9 @@
 
 module_name: HIL
 actuator_output:
+  config_parameters:
+    - param: 'HIL_ACT_DRNG'
+      label: 'Dynamic Range'
   show_subgroups_if: 'SYS_HITL>0'
   output_groups:
     - param_prefix: HIL_ACT

--- a/src/modules/simulation/pwm_out_sim/module_sim.yaml
+++ b/src/modules/simulation/pwm_out_sim/module_sim.yaml
@@ -1,6 +1,9 @@
 
 module_name: SIM
 actuator_output:
+  config_parameters:
+        - param: 'PWM_MAIN_DRNG'
+          label: 'Dynamic Range'
   output_groups:
     - param_prefix: PWM_MAIN
       channel_label: Channel

--- a/validation/module_schema.yaml
+++ b/validation/module_schema.yaml
@@ -246,6 +246,10 @@ actuator_output:
                       # parameter name
                       type: string
                       required: true
+                  param_prefix:
+                      # prefix to apply to the parameter name
+                      type: string
+                      required: false
                   label:
                       # human-readable label
                       type: string
@@ -428,6 +432,10 @@ actuator_output:
                                   # parameter name
                                   type: string
                                   required: true
+                              param_prefix:
+                                  # prefix to apply to the parameter name
+                                  type: string
+                                  required: false
                               label:
                                   # human-readable label
                                   type: string


### PR DESCRIPTION
Re-implementation of 103d7158adc2c6f5e8057101634cea050b99735c for 1.15.

Since this uses "modern" actuator setup, dynalim parameters can be set from "Actuators" pane of QGC.

Sim:
<img width="325" height="727" alt="image" src="https://github.com/user-attachments/assets/d17ca94a-7ee2-416f-a645-f3a6442e69ba" />

Cube Orange:
<img width="512" height="667" alt="image" src="https://github.com/user-attachments/assets/31e30a00-6d71-4aef-91fe-2ff2847cc1be" />

<img width="512" height="667" alt="image" src="https://github.com/user-attachments/assets/3e1a4f76-e80a-4459-99b7-337f5d70ecb8" />

<img width="491" height="935" alt="image" src="https://github.com/user-attachments/assets/ac74f84d-2d15-4d71-9ab8-4ed0dcc2ff34" />

<img width="771" height="936" alt="image" src="https://github.com/user-attachments/assets/7af3dcca-63c8-4ecd-8333-558d5cc101b4" />
