### PR TITLE
adsb: hide "traffic resolved" warnings

### DIFF
--- a/src/lib/adsb/AdsbConflict.cpp
+++ b/src/lib/adsb/AdsbConflict.cpp
@@ -197,7 +197,7 @@ bool AdsbConflict::handle_traffic_conflict()
 		break;
 
 	case TRAFFIC_STATE::REMOVE_OLD_CONFLICT: {
-			events::send<uint32_t>(events::ID("navigator_traffic_resolved"), events::Log::Notice,
+			events::send<uint32_t>(events::ID("navigator_traffic_resolved"), events::Log::Debug,
 					       "Traffic Conflict Resolved {1}!",
 					       _transponder_report.icao_address);
 			_last_traffic_warning_time = hrt_absolute_time();


### PR DESCRIPTION
During test flight, pilot complained about annoying traffic warnings about "resolved" conflicts from a HemsWX drop.
<img width="520" height="237" alt="image" src="https://github.com/user-attachments/assets/0baa8b8b-916a-4790-862b-aa069109975f" />

These messages are of no relevance to us the way we use traffic warnings.

QGC doesn't show "Debug" level warnings, so this is the same as hiding them.

Yes, this is in the "adsb" library, but also affects the traffic data we inject over MAVLink