### PR TITLE
Mission RTL flight mode

### DIFF
--- a/Tools/aviant/sitl.Dockerfile
+++ b/Tools/aviant/sitl.Dockerfile
@@ -1,0 +1,12 @@
+FROM px4io/px4-dev-simulation-focal
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/Oslo
+
+RUN groupadd -r px4 -g 1000 && useradd -m -u 1000 -r -g px4 px4
+USER px4
+
+RUN echo "set auto-load safe-path /" > /home/px4/.gdbinit
+RUN echo "handle SIG32 noprint nostop" >> /home/px4/.gdbinit
+
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["/bin/bash"]

--- a/Tools/aviant/sitl_docker.sh
+++ b/Tools/aviant/sitl_docker.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+DOCKER_USER_FLAG=""
+if [[ ! $(docker info | grep "Docker Root Dir") =~ "/var/lib/docker" ]]; then
+    # rootless docker, needs user flag
+    DOCKER_USER_FLAG="--user=root"
+    if [[ $(id -u) != 0 ]]; then
+        # TODO make it runnable without network=host
+        echo "ERROR: Must be root for --network=host"
+        exit 1
+    fi
+fi
+
+DIR_OF_THIS_SCRIPT="$(dirname "$(realpath "$0")")"
+
+# We need to mount the source dir with the same path as on the host machine
+# in order to get correct paths in compile_commands.json
+HOST_PX4_DIR="$(dirname "$(dirname "$DIR_OF_THIS_SCRIPT")")"
+
+# verify correct directory
+if [[ ! -d "$HOST_PX4_DIR/src" ]]; then
+    echo "ERROR: failed to detect px4 directory: $HOST_PX4_DIR has no src"
+    exit 1
+fi
+
+docker build -t aviantsitl -f "${DIR_OF_THIS_SCRIPT}/sitl.Dockerfile" .
+
+SITL_SUFFIX=""
+if [[ "${1:-}" == "debug" ]]; then
+    SITL_SUFFIX="_gdb"
+fi
+
+SITL_CMD="make px4_sitl gazebo_standard_vtol$SITL_SUFFIX"
+
+#--init ensures SIGINT is passed to all child processes
+docker run -it --rm --init \
+    --network=host \
+    --env=HEADLESS=1 \
+    --env=PX4_SIM_SPEED_FACTOR=3 \
+    --volume="${HOST_PX4_DIR}:${HOST_PX4_DIR}" \
+    --workdir="${HOST_PX4_DIR}" \
+    ${DOCKER_USER_FLAG} \
+    aviantsitl "$SITL_CMD"

--- a/msg/VehicleStatus.msg
+++ b/msg/VehicleStatus.msg
@@ -62,7 +62,8 @@ uint8 NAVIGATION_STATE_EXTERNAL5 = 27
 uint8 NAVIGATION_STATE_EXTERNAL6 = 28
 uint8 NAVIGATION_STATE_EXTERNAL7 = 29
 uint8 NAVIGATION_STATE_EXTERNAL8 = 30
-uint8 NAVIGATION_STATE_MAX = 31
+uint8 NAVIGATION_STATE_AUTO_MISSION_RTL = 31    # Auto return to launch mode following mission path
+uint8 NAVIGATION_STATE_MAX = 32
 
 uint8 executor_in_charge                        # Current mode executor in charge (0=Autopilot)
 

--- a/src/lib/events/enums.json
+++ b/src/lib/events/enums.json
@@ -417,22 +417,26 @@
                             "description": "Hold"
                         },
                         "6": {
+                            "name": "mission_rtl",
+                            "description": "MissionRTL"
+                        },
+                        "7": {
                             "name": "rtl",
                             "description": "RTL"
                         },
-                        "7": {
+                        "8": {
                             "name": "land",
                             "description": "Land"
                         },
-                        "8": {
+                        "9": {
                             "name": "descend",
                             "description": "Descend"
                         },
-                        "9": {
+                        "10": {
                             "name": "disarm",
                             "description": "disarm"
                         },
-                        "10": {
+                        "11": {
                             "name": "terminate",
                             "description": "terminate"
                         }
@@ -603,6 +607,10 @@
                         "23": {
                             "name": "external8",
                             "description": "External 8"
+                        },
+                        "24": {
+                            "name": "auto_mission_rtl",
+                            "description": "Mission RTL"
                         },
                         "255": {
                             "name": "unknown",

--- a/src/lib/modes/ui.hpp
+++ b/src/lib/modes/ui.hpp
@@ -61,9 +61,10 @@ static inline uint32_t getValidNavStates()
 	       (1u << vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET) |
 	       (1u << vehicle_status_s::NAVIGATION_STATE_AUTO_PRECLAND) |
 	       (1u << vehicle_status_s::NAVIGATION_STATE_ORBIT) |
-	       (1u << vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF);
+	       (1u << vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF) |
+	       (1u << vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL);
 
-	static_assert(vehicle_status_s::NAVIGATION_STATE_MAX  == 31, "update valid nav states");
+	static_assert(vehicle_status_s::NAVIGATION_STATE_MAX  == 32, "update valid nav states");
 }
 
 const char *const nav_state_names[vehicle_status_s::NAVIGATION_STATE_MAX] = {
@@ -98,6 +99,7 @@ const char *const nav_state_names[vehicle_status_s::NAVIGATION_STATE_MAX] = {
 	"External 6",
 	"External 7",
 	"External 8",
+	"Mission RTL",
 };
 
 /**

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -847,6 +847,10 @@ Commander::handle_command(const vehicle_command_s &cmd)
 							desired_nav_state = vehicle_status_s::NAVIGATION_STATE_EXTERNAL1 + (custom_sub_mode - PX4_CUSTOM_SUB_MODE_EXTERNAL1);
 							break;
 
+						case PX4_CUSTOM_SUB_MODE_AUTO_MISSION_RTL:
+							desired_nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL;
+							break;
+
 						default:
 							main_ret = TRANSITION_DENIED;
 							mavlink_log_critical(&_mavlink_log_pub, "Unsupported auto mode\t");

--- a/src/modules/commander/ModeUtil/control_mode.cpp
+++ b/src/modules/commander/ModeUtil/control_mode.cpp
@@ -84,6 +84,7 @@ void getVehicleControlMode(uint8_t nav_state, uint8_t vehicle_type,
 		break;
 
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_RTL:
+	case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL:
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_LAND:
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_PRECLAND:
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION:

--- a/src/modules/commander/ModeUtil/conversions.hpp
+++ b/src/modules/commander/ModeUtil/conversions.hpp
@@ -93,9 +93,11 @@ static inline navigation_mode_t navigation_mode(uint8_t nav_state)
 	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL7: return navigation_mode_t::external7;
 
 	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL8: return navigation_mode_t::external8;
+
+	case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL: return navigation_mode_t::auto_mission_rtl;
 	}
 
-	static_assert(vehicle_status_s::NAVIGATION_STATE_MAX == 31, "update navigation mode map");
+	static_assert(vehicle_status_s::NAVIGATION_STATE_MAX == 32, "update navigation mode map");
 
 	return navigation_mode_t::unknown;
 }

--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -113,6 +113,17 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_RTL, flags.mode_req_home_position);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_RTL, flags.mode_req_prevent_arming);
 
+	// NAVIGATION_STATE_AUTO_MISSION_RTL
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL, flags.mode_req_angular_velocity);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL, flags.mode_req_attitude);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL, flags.mode_req_local_position);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL, flags.mode_req_global_position);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL, flags.mode_req_local_alt);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL, flags.mode_req_home_position);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL, flags.mode_req_prevent_arming);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL, flags.mode_req_mission);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL, flags.mode_req_wind_and_flight_time_compliance);
+
 	// NAVIGATION_STATE_ACRO
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_ACRO, flags.mode_req_angular_velocity);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_ACRO, flags.mode_req_manual_control);
@@ -180,7 +191,7 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 
 	// NAVIGATION_STATE_EXTERNALx: handled outside
 
-	static_assert(vehicle_status_s::NAVIGATION_STATE_MAX == 31, "update mode requirements");
+	static_assert(vehicle_status_s::NAVIGATION_STATE_MAX == 32, "update mode requirements");
 }
 
 } // namespace mode_util

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -641,8 +641,9 @@ PARAM_DEFINE_INT32(COM_TAKEOFF_ACT, 0);
  * @value 3 Land mode
  * @value 5 Terminate
  * @value 6 Disarm
+ * @value 7 Mission return mode
  * @min 0
- * @max 6
+ * @max 7
  *
  * @group Commander
  */

--- a/src/modules/commander/failsafe/emscripten_template.html
+++ b/src/modules/commander/failsafe/emscripten_template.html
@@ -202,6 +202,7 @@
                                 <option value="22">AUTO_VTOL_TAKEOFF</option>
                                 <option value="14">OFFBOARD</option>
                                 <option value="21">ORBIT</option>
+                                <option value="31">AUTO_MISSION_RTL</option>
                             </select>
                             </td>
                             <td></td>

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -579,6 +579,12 @@ FailsafeBase::Action Failsafe::checkModeFallback(const failsafe_flags_s &status_
 		action = Action::MissionRTL;
 	}
 
+	if (user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL) {
+		// RTL needs to be treated as an Action to not be overridden by HOLD/MRTL actions when the mode is user_selected.
+		// This is because the fallback happens in the failsafe logic.
+		action = Action::RTL;
+	}
+
 	// offboard signal
 	if (status_flags.offboard_control_signal_lost && (status_flags.mode_req_offboard_signal & (1u << user_intended_mode))) {
 		action = fromOffboardLossActParam(_param_com_obl_rc_act.get(), user_intended_mode);

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -73,6 +73,11 @@ FailsafeBase::ActionOptions Failsafe::fromNavDllOrRclActParam(int param_value)
 		options.action = Action::Disarm;
 		break;
 
+	case gcs_connection_loss_failsafe_mode::Mission_return_mode:
+		options.action = Action::MissionRTL;
+		options.clear_condition = ClearCondition::OnModeChangeOrDisarm;
+		break;
+
 	default:
 		options.action = Action::None;
 		break;
@@ -567,6 +572,12 @@ FailsafeBase::Action Failsafe::checkModeFallback(const failsafe_flags_s &status_
 		uint8_t user_intended_mode) const
 {
 	Action action = Action::None;
+
+	if (user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL) {
+		// MissionRTL needs to be treated as an Action for correct fallback to RTL when the mode is user_selected.
+		// This is because the fallback happens in the failsafe logic.
+		action = Action::MissionRTL;
+	}
 
 	// offboard signal
 	if (status_flags.offboard_control_signal_lost && (status_flags.mode_req_offboard_signal & (1u << user_intended_mode))) {

--- a/src/modules/commander/failsafe/failsafe.h
+++ b/src/modules/commander/failsafe/failsafe.h
@@ -114,6 +114,7 @@ private:
 		Land_mode = 3,
 		Terminate = 5,
 		Disarm = 6,
+		Mission_return_mode = 7,
 	};
 
 	enum class command_after_quadchute : int32_t {
@@ -194,4 +195,3 @@ private:
 				       );
 
 };
-

--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -231,7 +231,7 @@ void FailsafeBase::notifyUser(uint8_t user_intended_mode, Action action, Action 
 				events::send<uint32_t, events::px4::enums::failsafe_action_t>(
 					events::ID("commander_failsafe_enter_generic"),
 				{events::Log::Critical, events::LogInternal::Warning},
-				"Failsafe activated: Autopilot disengaged, switching to {2}", mavlink_mode, failsafe_action);
+				"Failsafe activated: Switching to {2}", mavlink_mode, failsafe_action);
 			}
 
 		} else {

--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -547,6 +547,26 @@ void FailsafeBase::getSelectedAction(const State &state, const failsafe_flags_s 
 		returned_state.cause = Cause::Generic;
 
 	// fallthrough
+	case Action::MissionRTL:
+
+		/*
+		Skip MissionRTL if we're falling though, but we need to place
+		mission RTL here so it can fall through to other actions.
+
+		We also want to fall through to RTL if we're not in fixedwing mode,
+		since the distance home is likely too far to fly in multirotor mode
+		*/
+		if (selected_action == Action::MissionRTL &&
+		    state.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING &&
+		    modeCanRun(status_flags, vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL)
+		   ) {
+			selected_action = Action::MissionRTL;
+			break;
+		}
+
+		returned_state.cause = Cause::Generic;
+
+	// fallthrough
 	case Action::RTL:
 		if (modeCanRun(status_flags, vehicle_status_s::NAVIGATION_STATE_AUTO_RTL)) {
 			selected_action = Action::RTL;
@@ -591,7 +611,8 @@ void FailsafeBase::getSelectedAction(const State &state, const failsafe_flags_s 
 	// UX improvement (this is optional for safety): change failsafe to a warning in certain situations.
 	// If already landing, do not go into RTL
 	if (returned_state.updated_user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_LAND) {
-		if ((selected_action == Action::RTL || returned_state.delayed_action == Action::RTL)
+		if ((selected_action == Action::RTL || returned_state.delayed_action == Action::RTL || selected_action
+		     == Action::MissionRTL || returned_state.delayed_action == Action::MissionRTL)
 		    && modeCanRun(status_flags, vehicle_status_s::NAVIGATION_STATE_AUTO_LAND)) {
 			selected_action = Action::Warn;
 			returned_state.delayed_action = Action::None;
@@ -601,7 +622,8 @@ void FailsafeBase::getSelectedAction(const State &state, const failsafe_flags_s 
 	// If already precision landing, do not go into RTL or Land
 	if (returned_state.updated_user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_PRECLAND) {
 		if ((selected_action == Action::RTL || selected_action == Action::Land ||
-		     returned_state.delayed_action == Action::RTL || returned_state.delayed_action == Action::Land)
+		     returned_state.delayed_action == Action::RTL || returned_state.delayed_action == Action::Land ||
+		     returned_state.delayed_action == Action::MissionRTL)
 		    && modeCanRun(status_flags, vehicle_status_s::NAVIGATION_STATE_AUTO_PRECLAND)) {
 			selected_action = Action::Warn;
 			returned_state.delayed_action = Action::None;
@@ -612,7 +634,8 @@ void FailsafeBase::getSelectedAction(const State &state, const failsafe_flags_s 
 bool FailsafeBase::actionAllowsUserTakeover(Action action) const
 {
 	// Stick-controlled modes do not need user takeover
-	return action == Action::Hold || action == Action::RTL || action == Action::Land || action == Action::Descend;
+	return action == Action::Hold || action == Action::RTL || action == Action::Land || action == Action::Descend ||
+	       action == Action::MissionRTL;
 }
 
 void FailsafeBase::clearDelayIfNeeded(const State &state,
@@ -645,6 +668,8 @@ uint8_t FailsafeBase::modeFromAction(const Action &action, uint8_t user_intended
 	case Action::Hold: return vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER;
 
 	case Action::RTL: return vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
+
+	case Action::MissionRTL: return vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL;
 
 	case Action::Land: return vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
 

--- a/src/modules/commander/failsafe/framework.h
+++ b/src/modules/commander/failsafe/framework.h
@@ -60,6 +60,7 @@ public:
 		FallbackStab,
 
 		Hold,
+		MissionRTL,
 		RTL,
 		Land,
 		Descend,
@@ -102,6 +103,8 @@ public:
 		case Action::FallbackStab: return "Fallback to Stabilized";
 
 		case Action::Hold: return "Hold";
+
+		case Action::MissionRTL: return "Mission RTL";
 
 		case Action::RTL: return "RTL";
 

--- a/src/modules/commander/px4_custom_mode.h
+++ b/src/modules/commander/px4_custom_mode.h
@@ -73,6 +73,7 @@ enum PX4_CUSTOM_SUB_MODE_AUTO {
 	PX4_CUSTOM_SUB_MODE_EXTERNAL6,
 	PX4_CUSTOM_SUB_MODE_EXTERNAL7,
 	PX4_CUSTOM_SUB_MODE_EXTERNAL8,
+	PX4_CUSTOM_SUB_MODE_AUTO_MISSION_RTL,
 };
 
 enum PX4_CUSTOM_SUB_MODE_POSCTL {
@@ -225,6 +226,11 @@ static inline union px4_custom_mode get_px4_custom_mode(uint8_t nav_state)
 	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL8:
 		custom_mode.main_mode = PX4_CUSTOM_MAIN_MODE_AUTO;
 		custom_mode.sub_mode = PX4_CUSTOM_SUB_MODE_EXTERNAL8;
+		break;
+
+	case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL:
+		custom_mode.main_mode = PX4_CUSTOM_MAIN_MODE_AUTO;
+		custom_mode.sub_mode = PX4_CUSTOM_SUB_MODE_AUTO_MISSION_RTL;
 		break;
 	}
 

--- a/src/modules/navigator/CMakeLists.txt
+++ b/src/modules/navigator/CMakeLists.txt
@@ -42,10 +42,13 @@ set(NAVIGATOR_SOURCES
 	mission.cpp
 	loiter.cpp
 	rtl.cpp
+	mission_rtl.cpp
 	rtl_direct.cpp
 	rtl_direct_mission_land.cpp
 	rtl_mission_fast.cpp
 	rtl_mission_fast_reverse.cpp
+	missionrtl_mission_fast.cpp
+	missionrtl_mission_fast_reverse.cpp
 	takeoff.cpp
 	land.cpp
 	precland.cpp

--- a/src/modules/navigator/mission_rtl.cpp
+++ b/src/modules/navigator/mission_rtl.cpp
@@ -1,0 +1,208 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2013-2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file mission_rtl.cpp
+ *
+ * Aviant custom
+ * Helper class to access Mission RTL as a flight mode
+ *
+ */
+
+#include "mission_rtl.h"
+#include "navigator.h"
+#include "mission_block.h"
+#include "navigator/mission_base.h"
+#include "navigator/navigation.h"
+#include "px4_platform_common/defines.h"
+
+#include <drivers/drv_hrt.h>
+#include <px4_platform_common/events.h>
+#include <geo/geo.h>
+
+using namespace time_literals;
+using namespace math;
+using matrix::wrap_pi;
+
+MissionRTL::MissionRTL(Navigator *navigator) :
+	NavigatorMode(navigator)
+{
+	// Does not matter if this is Fast or FastReverse
+	// One needs to exist before activation to have a mission
+	// We can read the closest waypoint from
+	_mission_handle = new MissionRtlMissionFast(_navigator);
+}
+
+void MissionRTL::on_inactivation()
+{
+}
+
+void MissionRTL::on_inactive()
+{
+	_mission_handle->on_inactive();
+}
+
+void MissionRTL::on_activation()
+{
+	// If we're not already in mission mode,
+	// run on_activation once to select the closest mission item
+	// before we use it to decide whether to reverse or not.
+	if (already_in_mission_mode) {
+		PX4_INFO("MissionRTL was activated from mission mode, keeping the selected waypoint");
+
+	} else {
+		_mission_handle->on_activation(false);
+	}
+
+	const mission_s mission_info = _mission_handle->getMissionInfo();
+	float distance_forwards_m{0};
+	float distance_backwards_m{0};
+	bool any_winch_commands_forwards{false};
+	bool any_winch_commands_backwards{false};
+
+	bool failed_to_read_any_mission_item{false};
+	mission_item_s previous_item{0};
+	mission_item_s current_item{0};
+
+	// Note: Home location is not part of the mission here.
+	// That is fine, just means that the distance from takeoff to
+	// the first waypoint is not counted
+	for (int item_idx = 0; item_idx < mission_info.count; item_idx++) {
+		const bool load_success = _mission_handle->getMissionItem(item_idx, &current_item);
+
+		if (!load_success) {
+			failed_to_read_any_mission_item = true;
+			break;
+		}
+
+		if (current_item.nav_cmd == NAV_CMD_DO_WINCH) {
+			if (item_idx < mission_info.current_seq) {
+				any_winch_commands_backwards = true;
+
+			} else {
+				any_winch_commands_forwards = true;
+			}
+		}
+
+		if (!_mission_handle->item_contains_position(current_item)) { continue; }
+
+		if (previous_item.nav_cmd == 0) {  // Uninitialized
+			previous_item = current_item;
+			continue;
+		}
+
+		float dist_xy_m, dist_z_m;
+		get_distance_to_point_global_wgs84(
+			previous_item.lat,
+			previous_item.lon,
+			previous_item.altitude,
+			current_item.lat,
+			current_item.lon,
+			current_item.altitude,
+			&dist_xy_m,
+			&dist_z_m
+		);
+		const float distance_m = sqrtf(dist_xy_m * dist_xy_m + dist_z_m * dist_z_m);
+
+		if (item_idx <= mission_info.current_seq) {
+			// Note: this estimate is correct if we were not already in mission mode,
+			// but if we were already in mission mode, the reverse distance should really
+			// be counted up to the previous waypoint instead of the current one.
+			// We choose to accept this slight inaccuracy
+			// in order to reduce the complexity of the direction logic.
+			distance_forwards_m += distance_m;
+
+		} else {
+			distance_backwards_m += distance_m;
+		}
+
+		previous_item = current_item;
+	}
+
+	bool should_reverse = false;
+
+	// We choose to disregard the winch commands if they are both in front and behind us,
+	// since it's not immediately obvious which direction is desired.
+	if (failed_to_read_any_mission_item) {
+		should_reverse = (mission_info.current_seq < mission_info.count / 2);
+		PX4_INFO("MissionRTL: backtrack=%d because of waypoint index (%d of %d)",
+			 static_cast<int>(should_reverse),
+			 static_cast<int>(mission_info.current_seq),
+			 static_cast<int>(mission_info.count)
+			);
+
+	} else {
+		if (any_winch_commands_forwards && !any_winch_commands_backwards) {
+			should_reverse = true;
+			PX4_INFO("MissionRTl: backtracking because of winch command on the forwards path");
+
+		} else if (any_winch_commands_backwards && !any_winch_commands_forwards) {
+			should_reverse = false;
+			PX4_INFO("MissionRTl: fast forward because of winch command on the reverse path");
+
+		} else if (distance_forwards_m < distance_backwards_m) {
+			should_reverse = true;
+			PX4_INFO("MissionRTL: backtracking because backwards=%.3f m < forwards=%.3f m",
+				 static_cast<double>(distance_forwards_m),
+				 static_cast<double>(distance_backwards_m));
+
+		} else if (distance_forwards_m > distance_backwards_m) {
+			should_reverse = false;
+			PX4_INFO("MissionRTL: fast forward because backwards=%.3f m > forwards=%.3f m",
+				 static_cast<double>(distance_forwards_m),
+				 static_cast<double>(distance_backwards_m));
+
+		} else {
+			PX4_INFO("MissionRTL: defaulting to fast forward");
+			should_reverse = false;
+		}
+	}
+
+	delete _mission_handle;
+
+	if (should_reverse) {
+		_mission_handle = new MissionRtlMissionFastReverse(_navigator);
+
+	} else {
+		_mission_handle = new MissionRtlMissionFast(_navigator);
+	}
+
+	_mission_handle->on_inactive();  // Tick once to propagate the mission
+
+	_mission_handle->on_activation(already_in_mission_mode);
+}
+
+void MissionRTL::on_active()
+{
+	_mission_handle->on_active();
+}
+

--- a/src/modules/navigator/mission_rtl.h
+++ b/src/modules/navigator/mission_rtl.h
@@ -1,0 +1,74 @@
+/***************************************************************************
+ *
+ *   Copyright (c) 2013-2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file mission_rtl.h
+ *
+ * Aviant custom
+ * Helper class for Mission RTL
+ * Largely copied from RTL
+ */
+
+#pragma once
+
+#include <px4_platform_common/module_params.h>
+
+#include "navigator_mode.h"
+#include "missionrtl_base.h"
+#include "missionrtl_mission_fast.h"
+#include "missionrtl_mission_fast_reverse.h"
+
+#include <uORB/Publication.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionInterval.hpp>
+#include <uORB/topics/parameter_update.h>
+
+class Navigator;
+
+class MissionRTL : public NavigatorMode
+{
+public:
+	MissionRTL(Navigator *navigator);
+	~MissionRTL() = default;
+
+	void on_inactivation() override;
+	void on_inactive() override;
+	void on_activation() override;
+	void on_active() override;
+
+	void initialize() override {};
+
+	bool already_in_mission_mode{false};
+private:
+	MissionRtlBase *_mission_handle{nullptr};
+};
+

--- a/src/modules/navigator/missionrtl_base.h
+++ b/src/modules/navigator/missionrtl_base.h
@@ -1,0 +1,71 @@
+/***************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file missionrtl_base.h
+ *
+ * Helper class for MissionRTL modes using the mission
+ *
+ */
+
+#pragma once
+
+#include "mission_base.h"
+#include "navigator/navigation.h"
+#include <cstdlib>
+
+class MissionRtlBase : public MissionBase
+{
+public:
+	MissionRtlBase(Navigator *navigator, int32_t dataman_cache_size_signed):
+		MissionBase(navigator, dataman_cache_size_signed) {};
+	virtual ~MissionRtlBase() = default;
+
+	virtual void on_activation(bool from_mission_mode) = 0;
+
+	mission_s getMissionInfo() const { return _mission; };
+
+	bool getMissionItem(uint32_t idx, mission_item_s *dst)
+	{
+		if (idx >= _mission.count) { return false; }
+
+		const dm_item_t dm_item = static_cast<dm_item_t>(_mission.mission_dataman_id);
+		return _dataman_cache.loadWait(
+			       dm_item,
+			       idx,
+			       reinterpret_cast<uint8_t *>(dst),
+			       sizeof(mission_item_s),
+			       MAX_DATAMAN_LOAD_WAIT
+		       );
+	}
+
+};

--- a/src/modules/navigator/missionrtl_mission_fast.cpp
+++ b/src/modules/navigator/missionrtl_mission_fast.cpp
@@ -1,0 +1,154 @@
+/***************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file missionrtl_mission_fast.cpp
+ *
+ * Helper class for MissionRTL
+ *
+ */
+
+#include "missionrtl_mission_fast.h"
+#include "navigator.h"
+
+#include <drivers/drv_hrt.h>
+
+static constexpr int32_t DEFAULT_MISSION_FAST_CACHE_SIZE = 5;
+
+MissionRtlMissionFast::MissionRtlMissionFast(Navigator *navigator) :
+	MissionRtlBase(navigator, DEFAULT_MISSION_FAST_CACHE_SIZE)
+{
+
+}
+
+void MissionRtlMissionFast::on_activation(bool from_mission_mode)
+{
+	_home_pos_sub.update();
+
+	if (!from_mission_mode) {
+		_is_current_planned_mission_item_valid = setMissionToClosestItem(_global_pos_sub.get().lat, _global_pos_sub.get().lon,
+				_global_pos_sub.get().alt, _home_pos_sub.get().alt, _vehicle_status_sub.get()) == PX4_OK;
+	}
+
+	if (_land_detected_sub.get().landed) {
+		// already landed, no need to do anything, invalidad the position mission item.
+		_is_current_planned_mission_item_valid = false;
+	}
+
+	MissionBase::on_activation();
+}
+
+bool MissionRtlMissionFast::setNextMissionItem()
+{
+	return (goToNextPositionItem(false) == PX4_OK);
+}
+
+void MissionRtlMissionFast::setActiveMissionItems()
+{
+	WorkItemType new_work_item_type{WorkItemType::WORK_ITEM_TYPE_DEFAULT};
+	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+
+	// Transition to fixed wing if necessary.
+	if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING &&
+	    _vehicle_status_sub.get().is_vtol &&
+	    !_land_detected_sub.get().landed && _work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) {
+		set_vtol_transition_item(&_mission_item, vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW);
+		_mission_item.yaw = _navigator->get_local_position()->heading;
+
+		// keep current setpoints (FW position controller generates wp to track during transition)
+		pos_sp_triplet->current.type = position_setpoint_s::SETPOINT_TYPE_POSITION;
+
+		new_work_item_type = WorkItemType::WORK_ITEM_TYPE_TRANSITION_AFTER_TAKEOFF;
+
+	} else if (item_contains_position(_mission_item)) {
+
+		static constexpr size_t max_num_next_items{1u};
+		int32_t next_mission_items_index[max_num_next_items];
+		size_t num_found_items = 0;
+		getNextPositionItems(_mission.current_seq + 1, next_mission_items_index, num_found_items, max_num_next_items);
+
+		mission_item_s next_mission_items[max_num_next_items];
+		const dm_item_t mission_dataman_id = static_cast<dm_item_t>(_mission.mission_dataman_id);
+
+		for (size_t i = 0U; i < num_found_items; i++) {
+			mission_item_s next_mission_item;
+			bool success = _dataman_cache.loadWait(mission_dataman_id, next_mission_items_index[i],
+							       reinterpret_cast<uint8_t *>(&next_mission_item), sizeof(next_mission_item), MAX_DATAMAN_LOAD_WAIT);
+
+			if (success) {
+				next_mission_items[i] = next_mission_item;
+
+			} else {
+				num_found_items = i;
+				break;
+			}
+		}
+
+		if (_mission_item.nav_cmd == NAV_CMD_LAND ||
+		    _mission_item.nav_cmd == NAV_CMD_VTOL_LAND) {
+			handleLanding(new_work_item_type, next_mission_items, num_found_items);
+
+		} else {
+			// convert mission item to a simple waypoint, keep loiter to alt
+			if (_mission_item.nav_cmd != NAV_CMD_LOITER_TO_ALT) {
+				_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
+			}
+
+			_mission_item.autocontinue = true;
+			_mission_item.time_inside = 0.0f;
+
+			pos_sp_triplet->previous = pos_sp_triplet->current;
+		}
+
+
+
+		if (num_found_items > 0) {
+			mission_item_to_position_setpoint(next_mission_items[0u], &pos_sp_triplet->next);
+		}
+
+		mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+	}
+
+	issue_command(_mission_item);
+
+	/* set current work item type */
+	_work_item_type = new_work_item_type;
+
+	reset_mission_item_reached();
+
+	if (_mission_type == MissionType::MISSION_TYPE_MISSION) {
+		set_mission_result();
+	}
+
+	publish_navigator_mission_item(); // for logging
+	_navigator->set_position_setpoint_triplet_updated();
+}

--- a/src/modules/navigator/missionrtl_mission_fast.h
+++ b/src/modules/navigator/missionrtl_mission_fast.h
@@ -1,0 +1,61 @@
+/***************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file missionrtl_mission_fast.h
+ *
+ * Helper class for MissionRTL
+ */
+
+#pragma once
+
+#include "missionrtl_base.h"
+
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/home_position.h>
+
+class Navigator;
+
+class MissionRtlMissionFast : public MissionRtlBase
+{
+public:
+	MissionRtlMissionFast(Navigator *navigator);
+	~MissionRtlMissionFast() = default;
+
+	void on_activation(bool from_mission_mode) override;
+
+private:
+	bool setNextMissionItem() override;
+	void setActiveMissionItems() override;
+
+	uORB::SubscriptionData<home_position_s> _home_pos_sub{ORB_ID(home_position)};		/**< home position subscription */
+};

--- a/src/modules/navigator/missionrtl_mission_fast_reverse.cpp
+++ b/src/modules/navigator/missionrtl_mission_fast_reverse.cpp
@@ -1,0 +1,252 @@
+/***************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file missionrtl_mission_fast_reverse.cpp
+ *
+ * Helper class for MissionRTL
+ *
+ */
+
+#include "rtl_mission_fast_reverse.h"
+#include "navigator.h"
+
+#include <drivers/drv_hrt.h>
+
+static constexpr int32_t DEFAULT_MISSION_FAST_REVERSE_CACHE_SIZE = 5;
+
+MissionRtlMissionFastReverse::MissionRtlMissionFastReverse(Navigator *navigator) :
+	MissionRtlBase(navigator, -DEFAULT_MISSION_FAST_REVERSE_CACHE_SIZE)
+{
+
+}
+
+void MissionRtlMissionFastReverse::on_activation(bool from_mission_mode)
+{
+	_home_pos_sub.update();
+
+	if (!from_mission_mode) {
+		_is_current_planned_mission_item_valid = setMissionToClosestItem(_global_pos_sub.get().lat, _global_pos_sub.get().lon,
+				_global_pos_sub.get().alt, _home_pos_sub.get().alt, _vehicle_status_sub.get()) == PX4_OK;
+	}
+
+	if (_land_detected_sub.get().landed) {
+		// already landed, no need to do anything, invalidate the position mission item.
+		_is_current_planned_mission_item_valid = false;
+	}
+
+	MissionBase::on_activation();
+
+	if (from_mission_mode) {
+		// Advance the mission to select the "previous" waypoint in the normal direction
+		// important to set this after MissionBase::on_activation, so that
+		// the previous waypoint in the triplet is set correctly
+		advance_mission();
+		set_mission_items();
+	}
+}
+
+void MissionRtlMissionFastReverse::on_active()
+{
+	_home_pos_sub.update();
+	MissionBase::on_active();
+}
+
+bool MissionRtlMissionFastReverse::setNextMissionItem()
+{
+	return (goToPreviousPositionItem(false) == PX4_OK);
+}
+
+void MissionRtlMissionFastReverse::setActiveMissionItems()
+{
+	WorkItemType new_work_item_type{WorkItemType::WORK_ITEM_TYPE_DEFAULT};
+	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+
+	// Transition to fixed wing if necessary.
+	if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING &&
+	    _vehicle_status_sub.get().is_vtol &&
+	    !_land_detected_sub.get().landed && _work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) {
+		set_vtol_transition_item(&_mission_item, vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW);
+		_mission_item.yaw = _navigator->get_local_position()->heading;
+
+		// keep current setpoints (FW position controller generates wp to track during transition)
+		pos_sp_triplet->current.type = position_setpoint_s::SETPOINT_TYPE_POSITION;
+
+		new_work_item_type = WorkItemType::WORK_ITEM_TYPE_TRANSITION_AFTER_TAKEOFF;
+
+	} else if (item_contains_position(_mission_item)) {
+		int32_t next_mission_item_index;
+		size_t num_found_items = 0;
+		getPreviousPositionItems(_mission.current_seq, &next_mission_item_index, num_found_items, 1u);
+
+		// If the current item is a takeoff item or there is no further position item start landing.
+		if (_mission_item.nav_cmd == NAV_CMD_TAKEOFF ||
+		    _mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF ||
+		    num_found_items == 0) {
+			handleLanding(new_work_item_type);
+
+		} else {
+			// convert mission item to a simple waypoint, keep loiter to alt
+			if (_mission_item.nav_cmd != NAV_CMD_LOITER_TO_ALT) {
+				_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
+			}
+
+			_mission_item.autocontinue = true;
+			_mission_item.time_inside = 0.0f;
+
+			pos_sp_triplet->previous = pos_sp_triplet->current;
+		}
+
+		if (num_found_items > 0) {
+
+			const dm_item_t mission_dataman_id = static_cast<dm_item_t>(_mission.mission_dataman_id);
+			mission_item_s next_mission_item;
+			bool success = _dataman_cache.loadWait(mission_dataman_id, next_mission_item_index,
+							       reinterpret_cast<uint8_t *>(&next_mission_item), sizeof(mission_item_s), MAX_DATAMAN_LOAD_WAIT);
+
+			if (success) {
+				mission_item_to_position_setpoint(next_mission_item, &pos_sp_triplet->next);
+			}
+		}
+
+		mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+	}
+
+	issue_command(_mission_item);
+
+	/* set current work item type */
+	_work_item_type = new_work_item_type;
+
+	reset_mission_item_reached();
+
+	if (_mission_type == MissionType::MISSION_TYPE_MISSION) {
+		set_mission_result();
+	}
+
+	publish_navigator_mission_item(); // for logging
+	_navigator->set_position_setpoint_triplet_updated();
+}
+
+void MissionRtlMissionFastReverse::handleLanding(WorkItemType &new_work_item_type)
+{
+	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+
+	bool needs_to_land = !_land_detected_sub.get().landed;
+	bool vtol_in_fw = _vehicle_status_sub.get().is_vtol &&
+			  (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING);
+
+	if (needs_to_land) {
+		if (_work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) {
+			// Go to Take off location
+			new_work_item_type = WorkItemType::WORK_ITEM_TYPE_CLIMB;
+
+			if (!PX4_ISFINITE(_mission_item.altitude)) {
+				_mission_item.altitude = _global_pos_sub.get().alt;
+				_mission_item.altitude_is_relative = false;
+			}
+
+			_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
+			_mission_item.autocontinue = true;
+			_mission_item.time_inside = 0.0f;
+			_mission_item.vtol_back_transition = true;
+
+			pos_sp_triplet->previous = pos_sp_triplet->current;
+		}
+
+		if (vtol_in_fw) {
+			if (_work_item_type == WorkItemType::WORK_ITEM_TYPE_CLIMB) {
+				// Go to home location
+				new_work_item_type = WorkItemType::WORK_ITEM_TYPE_MOVE_TO_LAND;
+
+				float altitude = _global_pos_sub.get().alt;
+
+				if (pos_sp_triplet->current.valid && pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_POSITION) {
+					altitude = pos_sp_triplet->current.alt;
+				}
+
+				_mission_item.lat = _home_pos_sub.get().lat;
+				_mission_item.lon = _home_pos_sub.get().lon;
+				_mission_item.altitude = altitude;
+				_mission_item.altitude_is_relative = false;
+				_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
+				_mission_item.autocontinue = true;
+				_mission_item.time_inside = 0.0f;
+				_mission_item.vtol_back_transition = true;
+
+				pos_sp_triplet->previous = pos_sp_triplet->current;
+			}
+
+			/* transition to MC */
+			if (_work_item_type == WorkItemType::WORK_ITEM_TYPE_MOVE_TO_LAND) {
+
+				set_vtol_transition_item(&_mission_item, vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC);
+				_mission_item.altitude = _global_pos_sub.get().alt;
+				_mission_item.altitude_is_relative = false;
+				_mission_item.yaw = NAN;
+
+				new_work_item_type = WorkItemType::WORK_ITEM_TYPE_MOVE_TO_LAND_AFTER_TRANSITION;
+
+				// make previous setpoint invalid, such that there will be no prev-current line following
+				// if the vehicle drifted off the path during back-transition it should just go straight to the landing point
+				_navigator->reset_position_setpoint(pos_sp_triplet->previous);
+			}
+
+		} else if ((_work_item_type == WorkItemType::WORK_ITEM_TYPE_CLIMB ||
+			    _work_item_type == WorkItemType::WORK_ITEM_TYPE_MOVE_TO_LAND ||
+			    _work_item_type == WorkItemType::WORK_ITEM_TYPE_MOVE_TO_LAND_AFTER_TRANSITION)) {
+			_mission_item.nav_cmd = NAV_CMD_LAND;
+			_mission_item.lat = _home_pos_sub.get().lat;
+			_mission_item.lon = _home_pos_sub.get().lon;
+			_mission_item.yaw = NAN;
+
+			if ((_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) &&
+			    do_need_move_to_item()) {
+				new_work_item_type = WorkItemType::WORK_ITEM_TYPE_MOVE_TO_LAND;
+
+				_mission_item.altitude = _global_pos_sub.get().alt;
+				_mission_item.altitude_is_relative = false;
+				_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
+				_mission_item.autocontinue = true;
+				_mission_item.time_inside = 0.0f;
+
+				// make previous setpoint invalid, such that there will be no prev-current line following.
+				// if the vehicle drifted off the path during back-transition it should just go straight to the landing point
+				_navigator->reset_position_setpoint(pos_sp_triplet->previous);
+
+			} else {
+				_mission_item.altitude = _home_pos_sub.get().alt;
+				_mission_item.altitude_is_relative = false;
+				_navigator->reset_position_setpoint(pos_sp_triplet->previous);
+			}
+		}
+	}
+}

--- a/src/modules/navigator/missionrtl_mission_fast_reverse.h
+++ b/src/modules/navigator/missionrtl_mission_fast_reverse.h
@@ -1,0 +1,65 @@
+/***************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file rtl_mission_fast_reverse.h
+ *
+ * Helper class for RTL
+ *
+ * @author Julian Oes <julian@oes.ch>
+ * @author Anton Babushkin <anton.babushkin@me.com>
+ */
+
+#pragma once
+
+#include "missionrtl_base.h"
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/home_position.h>
+
+class Navigator;
+
+class MissionRtlMissionFastReverse : public MissionRtlBase
+{
+public:
+	MissionRtlMissionFastReverse(Navigator *navigator);
+	~MissionRtlMissionFastReverse() = default;
+
+	void on_activation(bool from_mission_mode) override;
+	void on_active() override;
+
+private:
+	bool setNextMissionItem() override;
+	void setActiveMissionItems() override;
+	void handleLanding(WorkItemType &new_work_item_type);
+
+	uORB::SubscriptionData<home_position_s> _home_pos_sub{ORB_ID(home_position)};		/**< home position subscription */
+};

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -41,6 +41,7 @@
 
 #pragma once
 
+#include "events/events_generated.h"
 #include "geofence.h"
 #include "land.h"
 #include "precland.h"
@@ -48,6 +49,7 @@
 #include "mission.h"
 #include "navigator_mode.h"
 #include "rtl.h"
+#include "mission_rtl.h"
 #include "takeoff.h"
 #if CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
 #include "vtol_takeoff.h"
@@ -90,7 +92,7 @@ using namespace time_literals;
 /**
  * Number of navigation modes that need on_active/on_inactive calls
  */
-#define NAVIGATOR_MODE_ARRAY_SIZE 8
+#define NAVIGATOR_MODE_ARRAY_SIZE 9
 
 class Navigator : public ModuleBase<Navigator>, public ModuleParams
 {
@@ -351,6 +353,7 @@ private:
 	Land		_land;			/**< class for handling land commands */
 	PrecLand	_precland;			/**< class for handling precision land commands */
 	RTL 		_rtl;				/**< class that handles RTL */
+	MissionRTL 	_mission_rtl;			/**< class that handles Mission RTL */
 	AdsbConflict 	_adsb_conflict;			/**< class that handles ADSB conflict avoidance */
 
 	NavigatorMode *_navigation_mode{nullptr};	/**< abstract pointer to current navigation mode class */

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -80,7 +80,8 @@ Navigator::Navigator() :
 #endif //CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
 	_land(this),
 	_precland(this),
-	_rtl(this)
+	_rtl(this),
+	_mission_rtl(this)
 {
 	/* Create a list of our possible navigation types */
 	_navigation_mode_array[0] = &_mission;
@@ -89,8 +90,9 @@ Navigator::Navigator() :
 	_navigation_mode_array[3] = &_takeoff;
 	_navigation_mode_array[4] = &_land;
 	_navigation_mode_array[5] = &_precland;
+	_navigation_mode_array[6] = &_mission_rtl;
 #if CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
-	_navigation_mode_array[6] = &_vtol_takeoff;
+	_navigation_mode_array[7] = &_vtol_takeoff;
 #endif //CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
 
 	/* iterate through navigation modes and initialize _mission_item for each */
@@ -786,6 +788,11 @@ void Navigator::run()
 
 			navigation_mode_new = &_rtl;
 
+			break;
+
+		case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION_RTL:
+			_mission_rtl.already_in_mission_mode = _navigation_mode == &_mission;
+			navigation_mode_new = &_mission_rtl;
 			break;
 
 		case vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF:


### PR DESCRIPTION
Breaking out Mission RTL in a separate flight mode in order to separate it from rallypoint RTL in failsafe actions, and be able to failsafe from mission RTL to rallypoint RTL.
The main change in behavior from the upstream "mission rtl_type" is the direction selection logic and not respecting jump-to items to avoid an infinite loop bug.

Falls back to RTL if not FW.
Since MissionRTL is not supported in MR mode, it triggers RTL as soon as the aircraft backtransitions. This is fine since the end result is the same (landed at the target location)

Edgecases that are not handled, but considered out of scope:
- If the drone falls back to RTL because it's MR, but we then transition to FW, it wil un-fallback to M-RTL. I don't see this happening in practice, and if it does it's not a big issue. 
- What if the winch waypoint is at the end of a long route transport mission? Then the aircraft will reverse, but not have enough charge to fly back home, and the battery failsafe will trigger.