### PR TITLE
rtl: rtl_type=1 don't choose home if another option exists

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -51,7 +51,7 @@ using namespace time_literals;
 using namespace math;
 using matrix::wrap_pi;
 
-static constexpr float MAX_DIST_FROM_HOME_FOR_LAND_APPROACHES{10.0f}; // [m] We don't consider safe points valid if the distance from the current home to the safe point is smaller than this distance
+static constexpr float MAX_DIST_FROM_HOME_FOR_LAND_APPROACHES{1.0f}; // [m] We don't consider safe points valid if the distance from the current home to the safe point is smaller than this distance
 static constexpr float MIN_DIST_THRESHOLD = 2.f;
 
 RTL::RTL(Navigator *navigator) :
@@ -377,9 +377,6 @@ void RTL::findRtlDestination(DestinationType &destination_type, PositionYawSetpo
 	rtl_position.yaw = _home_pos_sub.get().yaw;
 	destination_type = DestinationType::DESTINATION_TYPE_HOME;
 
-	const bool vtol_in_rw_mode = _vehicle_status_sub.get().is_vtol
-				     && (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING);
-
 	const bool vtol_in_fw_mode = _vehicle_status_sub.get().is_vtol
 				     && (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING);
 
@@ -389,8 +386,8 @@ void RTL::findRtlDestination(DestinationType &destination_type, PositionYawSetpo
 
 	_home_has_land_approach = hasVtolLandApproach(rtl_position);
 
-	if (((_param_rtl_type.get() == 1) && !vtol_in_rw_mode) || (vtol_in_fw_mode && (_param_rtl_approach_force.get() == 1)
-			&& !_home_has_land_approach)) {
+	if ((_param_rtl_type.get() == 1) || (vtol_in_fw_mode && (_param_rtl_approach_force.get() == 1)
+					     && !_home_has_land_approach)) {
 		// Set minimum distance to maximum value when RTL_TYPE is set to 1 and we are not in RW mode or we forces approach landing for vtol in fw and it is not defined for home.
 		min_dist = FLT_MAX;
 

--- a/src/modules/navigator/rtl_params.c
+++ b/src/modules/navigator/rtl_params.c
@@ -109,7 +109,7 @@ PARAM_DEFINE_FLOAT(RTL_MIN_DIST, 10.0f);
  * Return mode destination and flight path (home location, rally point, mission landing pattern, reverse mission)
  *
  * @value 0 Return to closest safe point (home or rally point) via direct path.
- * @value 1 Return to closest safe point other than home (mission landing pattern or rally point), via direct path. If no mission landing or rally points are defined return home via direct path. Always chose closest safe landing point if vehicle is a VTOL in hover mode.
+ * @value 1 Return to closest safe point other than home (mission landing pattern or rally point), via direct path. If no mission landing or rally points are defined return home via direct path.
  * @value 2 Return to a planned mission landing, if available, using the mission path, else return to home via the reverse mission path. Do not consider rally points.
  * @value 3 Return via direct path to closest destination: home, start of mission landing pattern or safe point. If the destination is a mission landing pattern, follow the pattern to land.
  * @group Return Mode


### PR DESCRIPTION
Needed for M-RTL to avoid landing on the takeoff stand.
I considered adding a new RTL_TYPE=4 instead, but consider this change so small that it's not necessary. LMK if you disagree @oystub, and we can discuss it. It's a quick fix.