### PR TITLE
mpc: minimum land speed for battery emergency

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -37,6 +37,7 @@
 #include "FlightTaskAuto.hpp"
 #include <mathlib/mathlib.h>
 #include <float.h>
+#include <uORB/topics/battery_status.h>
 
 using namespace matrix;
 
@@ -249,6 +250,12 @@ void FlightTaskAuto::_prepareLandSetpoints()
 
 	if (range_dist_available && _dist_to_bottom <= _param_mpc_land_alt3.get()) {
 		vertical_speed = _param_mpc_land_crawl_speed.get();
+	}
+
+	_sub_failsafe_flags.update();
+
+	if (_sub_failsafe_flags.get().battery_warning == battery_status_s::BATTERY_WARNING_EMERGENCY) {
+		vertical_speed = math::max(vertical_speed, _param_mpc_land_bat_emg.get());
 	}
 
 	if (_type_previous != WaypointType::land) {

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -40,6 +40,7 @@
 #pragma once
 
 #include "FlightTask.hpp"
+#include <uORB/topics/failsafe_flags.h>
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/position_setpoint.h>
 #include <uORB/topics/home_position.h>
@@ -175,6 +176,8 @@ protected:
 					_param_mpc_land_alt2, // altitude at which we descend at land speed
 					(ParamFloat<px4::params::MPC_LAND_ALT3>)
 					_param_mpc_land_alt3, // altitude where we switch to crawl speed, if LIDAR available
+					(ParamFloat<px4::params::MPC_LAND_BAT_EMG>)
+					_param_mpc_land_bat_emg, // minimum descent speed during battery emergency
 					(ParamFloat<px4::params::MPC_Z_V_AUTO_UP>) _param_mpc_z_v_auto_up,
 					(ParamFloat<px4::params::MPC_Z_V_AUTO_DN>) _param_mpc_z_v_auto_dn,
 					(ParamFloat<px4::params::MPC_TKO_SPEED>) _param_mpc_tko_speed,
@@ -187,6 +190,7 @@ private:
 	bool _yaw_lock{false}; /**< if within acceptance radius, lock yaw to current yaw */
 
 	uORB::SubscriptionData<position_setpoint_triplet_s> _sub_triplet_setpoint{ORB_ID(position_setpoint_triplet)};
+	uORB::SubscriptionData<failsafe_flags_s> _sub_failsafe_flags{ORB_ID(failsafe_flags)};
 
 	matrix::Vector3f
 	_triplet_target; /**< current triplet from navigator which may differ from the intenal one (_target) depending on the vehicle state. */

--- a/src/modules/mc_pos_control/multicopter_takeoff_land_params.c
+++ b/src/modules/mc_pos_control/multicopter_takeoff_land_params.c
@@ -112,6 +112,22 @@ PARAM_DEFINE_FLOAT(MPC_LAND_ALT3, 1.f);
 PARAM_DEFINE_FLOAT(MPC_LAND_SPEED, 0.7f);
 
 /**
+ * Minimum descent speed during battery emergency
+ *
+ * During a battery emergency, the land descend rate will not go below this value.
+ * This can be used to disable soft landing during battery emergency.
+ * Only affects auto land, not manual altitude mode.
+ *
+ * Has no effect if set to 0.
+ *
+ * @unit m/s
+ * @min 0
+ * @decimal 1
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_LAND_BAT_EMG, 0.0f);
+
+/**
  * Land crawl descend rate
  *
  * Used below MPC_LAND_ALT3 if distance sensor data is availabe.


### PR DESCRIPTION
## Background
In a battery emergency, it may be desirable to limit altitude-based reductions to vertical speed during landing. A hard landing might be preferable to running out of battery.

This especially applies if `MPC_LAND_CRWL` is enabled, since distance sensors can measure too low distance in foggy conditions, which would potentially cause a very slow landing, draining the battery.

## Solution
A new parameter, `MPC_LAND_BAT_EMG` is introduced, which acts as a lower bound for the descent speed during battery emergencies.

## Note on hard landings
Note that this still leaves the problem with hard landings when the distance sensor is marked as invalid. I initially changed
```c++
	if (range_dist_available && _dist_to_bottom <= _param_mpc_land_alt3.get()) {
		vertical_speed = _param_mpc_land_crawl_speed.get();
	}
```

to 
```c++
if (!range_dist_available ||  _dist_to_bottom <= _param_mpc_land_alt3.get())
```
as a quick fix for this, since we wouldn't have to worry about battery running out anymore.

However, due to concerns with motor overheating during long landings, I left it out of this PR.