### PR TITLE
vtol_att_control: add lookahead option to attitude quadchute

### DIFF
--- a/msg/VtolVehicleStatus.msg
+++ b/msg/VtolVehicleStatus.msg
@@ -13,3 +13,6 @@ bool fixed_wing_system_failure		# vehicle in fixed-wing system failure failsafe 
 
 float32 airspeed_filtered		# Filtered airspeed used during transition. NAN if invalid
 float32[4] mc_weights			# Multicopter blending weights for [roll, pitch, yaw, throttle]
+
+float32 lookahead_roll			# Predicted roll angle for quadchute lookahead [rad]
+float32 lookahead_pitch			# Predicted pitch angle for quadchute lookahead [rad]

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -254,6 +254,16 @@ VtolAttitudeControl::quadchute(QuadchuteReason reason)
 				     "Quad-chute triggered due to maximum roll angle exceeded");
 			break;
 
+		case QuadchuteReason::MaximumPitchExceededLookahead:
+			events::send(events::ID("vtol_att_ctrl_quadchute_max_pitch_la"), events::Log::Critical,
+				     "Quad-chute triggered due to maximum pitch angle exceeded (lookahead)");
+			break;
+
+		case QuadchuteReason::MaximumRollExceededLookahead:
+			events::send(events::ID("vtol_att_ctrl_quadchute_max_roll_la"), events::Log::Critical,
+				     "Quad-chute triggered due to maximum roll angle exceeded (lookahead)");
+			break;
+
 		case QuadchuteReason::None:
 			// should never get in here
 			return;
@@ -355,6 +365,7 @@ VtolAttitudeControl::Run()
 
 		_tecs_status_sub.update(&_tecs_status);
 		_land_detected_sub.update(&_land_detected);
+		_vehicle_angular_velocity_sub.update(&_vehicle_angular_velocity);
 
 		if (_home_position_sub.updated()) {
 			home_position_s home_position;
@@ -449,13 +460,15 @@ VtolAttitudeControl::Run()
 		_vehicle_thrust_setpoint1_pub.publish(_thrust_setpoint_1);
 
 		// Advertise/Publish vtol vehicle status
-		_vtol_vehicle_status.timestamp = hrt_absolute_time();
-		_vtol_vehicle_status_pub.publish(_vtol_vehicle_status);
 		_vtol_vehicle_status.airspeed_filtered = get_filtered_airspeed();
 		_vtol_vehicle_status.mc_weights[0] = _vtol_type->get_mc_roll_weight();
 		_vtol_vehicle_status.mc_weights[1] = _vtol_type->get_mc_pitch_weight();
 		_vtol_vehicle_status.mc_weights[2] = _vtol_type->get_mc_yaw_weight();
 		_vtol_vehicle_status.mc_weights[3] = _vtol_type->get_mc_throttle_weight();
+		_vtol_vehicle_status.lookahead_pitch = _vtol_type->get_qc_lookahead_pitch();
+		_vtol_vehicle_status.lookahead_roll = _vtol_type->get_qc_lookahead_roll();
+		_vtol_vehicle_status.timestamp = hrt_absolute_time();
+		_vtol_vehicle_status_pub.publish(_vtol_vehicle_status);
 
 		// Publish flaps/spoiler setpoint with configured deflection in Hover if in Auto.
 		// In Manual always published in FW rate controller, and in Auto FW in FW Position Controller.

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -85,6 +85,7 @@
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_thrust_setpoint.h>
 #include <uORB/topics/vehicle_torque_setpoint.h>
+#include <uORB/topics/vehicle_angular_velocity.h>
 #include "standard.h"
 #include "tailsitter.h"
 #include "tiltrotor.h"
@@ -146,6 +147,7 @@ public:
 	struct vehicle_thrust_setpoint_s 		*get_thrust_setpoint_1() {return &_thrust_setpoint_1;}
 	struct vtol_vehicle_status_s			*get_vtol_vehicle_status() {return &_vtol_vehicle_status;}
 	float get_home_position_z() { return _home_position_z; }
+	struct vehicle_angular_velocity_s	*get_angular_velocity() { return &_vehicle_angular_velocity; }
 
 private:
 	void Run() override;
@@ -173,6 +175,7 @@ private:
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
 	uORB::Subscription _vehicle_cmd_sub{ORB_ID(vehicle_command)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+	uORB::Subscription _vehicle_angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};
 
 	uORB::Publication<normalized_unsigned_setpoint_s>	_flaps_setpoint_pub{ORB_ID(flaps_setpoint)};
 	uORB::Publication<normalized_unsigned_setpoint_s>	_spoilers_setpoint_pub{ORB_ID(spoilers_setpoint)};
@@ -212,6 +215,7 @@ private:
 	vehicle_local_position_setpoint_s	_local_pos_sp{};
 	vehicle_status_s 			_vehicle_status{};
 	vtol_vehicle_status_s 			_vtol_vehicle_status{};
+	vehicle_angular_velocity_s		_vehicle_angular_velocity{};
 	float _home_position_z{NAN};
 
 	float _air_density{atmosphere::kAirDensitySeaLevelStandardAtmos};	// [kg/m^3]

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -256,6 +256,42 @@ PARAM_DEFINE_INT32(VT_FW_QC_P, 0);
 PARAM_DEFINE_INT32(VT_FW_QC_R, 0);
 
 /**
+ * Quad-chute pitch lookahead time
+ *
+ * Predicts future pitch attitude from angular velocity to trigger quadchute before pitch limits
+ * are exceeded, allowing reaction to a flip before it becomes unrecoverable.
+ * Increasing this parameter trades off false positives for faster reaction.
+ * Should not be much larger than the pitch time constant, otherwise it will trigger from
+ * normal pitching maneuvers. Set to 0 to disable.
+ *
+ * @unit s
+ * @min 0.0
+ * @max 1.0
+ * @decimal 2
+ * @increment 0.01
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_FW_QC_P_LA, 0.0f);
+
+/**
+ * Quad-chute roll lookahead time
+ *
+ * Predicts future roll attitude from angular velocity to trigger quadchute before roll limits
+ * are exceeded, allowing reaction to a flip before it becomes unrecoverable.
+ * Increasing this parameter trades off false positives for faster reaction.
+ * Should not be much larger than the roll time constant, otherwise it will trigger from
+ * normal rolling maneuvers. Set to 0 to disable.
+ *
+ * @unit s
+ * @min 0.0
+ * @max 1.0
+ * @decimal 2
+ * @increment 0.01
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_FW_QC_R_LA, 0.0f);
+
+/**
  * Quad-chute maximum height
  *
  * Maximum height above the ground (if available, otherwise above

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -82,6 +82,7 @@ VtolType::VtolType(VtolAttitudeControl *att_controller) :
 	_airspeed_validated = _attc->get_airspeed();
 	_tecs_status = _attc->get_tecs_status();
 	_land_detected = _attc->get_land_detected();
+	_vehicle_angular_velocity = _attc->get_angular_velocity();
 }
 
 bool VtolType::init()
@@ -110,6 +111,8 @@ void VtolType::update_mc_state()
 	_mc_pitch_weight = 1.0f;
 	_mc_yaw_weight = 1.0f;
 	_mc_throttle_weight = 1.0f;
+	_qc_lookahead_pitch = 0.0f;
+	_qc_lookahead_roll = 0.0f;
 }
 
 void VtolType::update_fw_state()
@@ -359,6 +362,53 @@ bool VtolType::isRollExceeded()
 	return false;
 }
 
+void VtolType::update_qc_lookahead_angles()
+{
+	const float p = _vehicle_angular_velocity->xyz[0];
+	const float q = _vehicle_angular_velocity->xyz[1];
+	const float r = _vehicle_angular_velocity->xyz[2];
+
+	if (!PX4_ISFINITE(p) || !PX4_ISFINITE(q) || !PX4_ISFINITE(r)) {
+		_qc_lookahead_pitch = NAN;
+		_qc_lookahead_roll = NAN;
+		return;
+	}
+
+	const Eulerf euler(Quatf(_v_att->q));
+	const float phi = euler.phi();
+
+	constexpr float MAX_PITCH_FOR_TAN = math::radians(89.f);
+	const float theta = math::constrain(euler.theta(), -MAX_PITCH_FOR_TAN, MAX_PITCH_FOR_TAN);
+
+	const float euler_pitch_rate = q * cosf(phi) - r * sinf(phi);
+	const float euler_roll_rate = p + (q * sinf(phi) + r * cosf(phi)) * tanf(theta);
+
+	_qc_lookahead_pitch = euler.theta() + _param_vt_fw_qc_p_la.get() * euler_pitch_rate;
+	_qc_lookahead_roll = euler.phi() + _param_vt_fw_qc_r_la.get() * euler_roll_rate;
+}
+
+bool VtolType::isPitchExceededLookahead()
+{
+	const float threshold_deg = static_cast<float>(_param_vt_fw_qc_p.get());
+
+	if (threshold_deg <= FLT_EPSILON || !PX4_ISFINITE(_qc_lookahead_pitch)) {
+		return false;
+	}
+
+	return fabsf(_qc_lookahead_pitch) > math::radians(threshold_deg);
+}
+
+bool VtolType::isRollExceededLookahead()
+{
+	const float threshold_deg = static_cast<float>(_param_vt_fw_qc_r.get());
+
+	if (threshold_deg <= FLT_EPSILON || !PX4_ISFINITE(_qc_lookahead_roll)) {
+		return false;
+	}
+
+	return fabsf(_qc_lookahead_roll) > math::radians(threshold_deg);
+}
+
 bool VtolType::isFrontTransitionTimeout()
 {
 	// check front transition timeout
@@ -391,8 +441,16 @@ QuadchuteReason VtolType::getQuadchuteReason()
 		return QuadchuteReason::MaximumPitchExceeded;
 	}
 
+	if (isPitchExceededLookahead()) {
+		return QuadchuteReason::MaximumPitchExceededLookahead;
+	}
+
 	if (isRollExceeded()) {
 		return QuadchuteReason::MaximumRollExceeded;
+	}
+
+	if (isRollExceededLookahead()) {
+		return QuadchuteReason::MaximumRollExceededLookahead;
 	}
 
 	if (isFrontTransitionTimeout()) {
@@ -418,6 +476,7 @@ void VtolType::handleSpecialExternalCommandQuadchute()
 void VtolType::check_quadchute_condition()
 {
 	handleSpecialExternalCommandQuadchute();
+	update_qc_lookahead_angles();
 
 	if (isQuadchuteEnabled()) {
 		QuadchuteReason reason = getQuadchuteReason();

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -92,6 +92,8 @@ enum class QuadchuteReason {
 	TransitionAltitudeLoss,
 	MaximumPitchExceeded,
 	MaximumRollExceeded,
+	MaximumPitchExceededLookahead,
+	MaximumRollExceededLookahead,
 };
 
 class VtolAttitudeControl;
@@ -191,6 +193,9 @@ public:
 	 */
 	bool isRollExceeded();
 
+	bool isPitchExceededLookahead();
+	bool isRollExceededLookahead();
+
 	/**
 	 *  @brief Indicates if the front transition duration has exceeded the timeout definded by VT_TRANS_TIMEOUT
 	 *
@@ -207,6 +212,7 @@ public:
 	 * Checks for fixed-wing failsafe condition and issues abort request if needed.
 	 */
 	void check_quadchute_condition();
+	void update_qc_lookahead_angles();
 
 	/**
 	 * Returns true if we're allowed to do a mode transition on the ground.
@@ -220,6 +226,8 @@ public:
 	float get_mc_pitch_weight() const { return _mc_pitch_weight; }
 	float get_mc_yaw_weight() const { return _mc_yaw_weight; }
 	float get_mc_throttle_weight() const { return _mc_throttle_weight; }
+	float get_qc_lookahead_pitch() const { return _qc_lookahead_pitch; }
+	float get_qc_lookahead_roll() const { return _qc_lookahead_roll; }
 
 	/**
 	 * Pusher assist in hover (pusher/pull for standard VTOL, motor tilt for tiltrotor)
@@ -294,6 +302,7 @@ protected:
 	const float		    			&_airspeed_filtered;					// filtered airspeed
 	struct tecs_status_s				*_tecs_status;
 	struct vehicle_land_detected_s			*_land_detected;
+	struct vehicle_angular_velocity_s		*_vehicle_angular_velocity;	// angular velocity for quadchute lookahead
 
 	struct vehicle_torque_setpoint_s 		*_torque_setpoint_0;
 	struct vehicle_torque_setpoint_s 		*_torque_setpoint_1;
@@ -304,6 +313,8 @@ protected:
 	float _mc_pitch_weight = 1.0f;	// weight for multicopter attitude controller pitch output
 	float _mc_yaw_weight = 1.0f;	// weight for multicopter attitude controller yaw output
 	float _mc_throttle_weight = 1.0f;	// weight for multicopter throttle command. Used to avoid
+	float _qc_lookahead_pitch = 0.0f;
+	float _qc_lookahead_roll = 0.0f;
 
 	// motors spinning up or cutting too fast when doing transitions.
 	float _thrust_transition = 0.0f;	// thrust value applied during a front transition (tailsitter & tiltrotor only)
@@ -339,6 +350,8 @@ protected:
 					(ParamFloat<px4::params::VT_QC_ALT_LOSS>) _param_vt_qc_alt_loss,
 					(ParamInt<px4::params::VT_FW_QC_P>) _param_vt_fw_qc_p,
 					(ParamInt<px4::params::VT_FW_QC_R>) _param_vt_fw_qc_r,
+					(ParamFloat<px4::params::VT_FW_QC_P_LA>) _param_vt_fw_qc_p_la,
+					(ParamFloat<px4::params::VT_FW_QC_R_LA>) _param_vt_fw_qc_r_la,
 					(ParamFloat<px4::params::VT_QC_T_ALT_LOSS>) _param_vt_qc_t_alt_loss,
 					(ParamInt<px4::params::VT_FW_QC_HMAX>) _param_quadchute_max_height,
 					(ParamFloat<px4::params::VT_F_TR_OL_TM>) _param_vt_f_tr_ol_tm,


### PR DESCRIPTION
See bottom of https://aviant.atlassian.net/wiki/spaces/TECHNICAL/pages/1990492169/2025-12-19+NT19+FW+quadchute+and+parachute+deployment#Add-a-roll-rate-trigger%3F for explanation of the idea