### PR TITLE
vtol_att_control: lookahead in roll/pitch quadchute

### DIFF
--- a/msg/vtol_vehicle_status.msg
+++ b/msg/vtol_vehicle_status.msg
@@ -16,5 +16,10 @@ bool fw_permanent_stab			# In fw mode stabilize attitude even if in manual mode
 float32 airspeed_filtered		# Filtered airspeed used during transition. NAN if invalid
 float32[4] mc_weights			# Multicopter blending weights for [roll, pitch, yaw, throttle]
 
-float32 lookahead_roll			# Predicted roll angle for quadchute lookahead [rad]
-float32 lookahead_pitch			# Predicted pitch angle for quadchute lookahead [rad]
+# Euler-based lookahead (old method with gimbal lock)
+float32 lookahead_roll_euler		# Predicted roll angle using Euler rates [rad]
+float32 lookahead_pitch_euler		# Predicted pitch angle using Euler rates [rad]
+
+# Quaternion-based lookahead (new method, singularity-free)
+float32 lookahead_roll_quat		# Predicted roll angle using quaternion integration [rad]
+float32 lookahead_pitch_quat		# Predicted pitch angle using quaternion integration [rad]

--- a/msg/vtol_vehicle_status.msg
+++ b/msg/vtol_vehicle_status.msg
@@ -15,3 +15,6 @@ bool fw_permanent_stab			# In fw mode stabilize attitude even if in manual mode
 
 float32 airspeed_filtered		# Filtered airspeed used during transition. NAN if invalid
 float32[4] mc_weights			# Multicopter blending weights for [roll, pitch, yaw, throttle]
+
+float32 lookahead_roll			# Predicted roll angle for quadchute lookahead [rad]
+float32 lookahead_pitch			# Predicted pitch angle for quadchute lookahead [rad]

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -120,7 +120,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("vehicle_roi", 1000);
 	add_topic("vehicle_status");
 	add_topic("vehicle_status_flags");
-	add_optional_topic("vtol_vehicle_status", 200);
+	add_optional_topic("vtol_vehicle_status", 0);  // 0 = maximum rate for lookahead comparison
 	add_topic("wind", 1000);
 
 	// multi topics

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -571,8 +571,11 @@ VtolAttitudeControl::Run()
 		_vtol_vehicle_status.mc_weights[1] = _vtol_type->_mc_pitch_weight;
 		_vtol_vehicle_status.mc_weights[2] = _vtol_type->_mc_yaw_weight;
 		_vtol_vehicle_status.mc_weights[3] = _vtol_type->_mc_throttle_weight;
-		_vtol_vehicle_status.lookahead_pitch = _vtol_type->get_qc_lookahead_pitch();
-		_vtol_vehicle_status.lookahead_roll = _vtol_type->get_qc_lookahead_roll();
+		// Publish both Euler and quaternion lookahead values for comparison
+		_vtol_vehicle_status.lookahead_pitch_euler = _vtol_type->get_qc_lookahead_pitch_euler();
+		_vtol_vehicle_status.lookahead_roll_euler = _vtol_type->get_qc_lookahead_roll_euler();
+		_vtol_vehicle_status.lookahead_pitch_quat = _vtol_type->get_qc_lookahead_pitch_quat();
+		_vtol_vehicle_status.lookahead_roll_quat = _vtol_type->get_qc_lookahead_roll_quat();
 		_vtol_vehicle_status.timestamp = hrt_absolute_time();
 		_vtol_vehicle_status_pub.publish(_vtol_vehicle_status);
 	}

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -83,6 +83,8 @@ VtolAttitudeControl::VtolAttitudeControl() :
 	_params_handles.fw_alt_err = param_find("VT_FW_ALT_ERR");
 	_params_handles.fw_qc_max_pitch = param_find("VT_FW_QC_P");
 	_params_handles.fw_qc_max_roll = param_find("VT_FW_QC_R");
+	_params_handles.vt_fw_qc_p_la = param_find("VT_FW_QC_P_LA");
+	_params_handles.vt_fw_qc_r_la = param_find("VT_FW_QC_R_LA");
 	_params_handles.front_trans_time_openloop = param_find("VT_F_TR_OL_TM");
 	_params_handles.front_trans_time_min = param_find("VT_TRANS_MIN_TM");
 
@@ -271,6 +273,18 @@ VtolAttitudeControl::quadchute(QuadchuteReason reason)
 			events::send(events::ID("vtol_att_ctrl_quadchute_max_roll"), events::Log::Critical,
 				     "Quadchute triggered, due to maximum roll angle exceeded");
 			break;
+
+		case QuadchuteReason::MaximumPitchExceededLookahead:
+			mavlink_log_critical(&_mavlink_log_pub, "Quadchute: maximum pitch exceeded (lookahead)\t");
+			events::send(events::ID("vtol_att_ctrl_quadchute_max_pitch_la"), events::Log::Critical,
+				     "Quadchute triggered, due to maximum pitch angle exceeded (lookahead)");
+			break;
+
+		case QuadchuteReason::MaximumRollExceededLookahead:
+			mavlink_log_critical(&_mavlink_log_pub, "Quadchute: maximum roll exceeded (lookahead)\t");
+			events::send(events::ID("vtol_att_ctrl_quadchute_max_roll_la"), events::Log::Critical,
+				     "Quadchute triggered, due to maximum roll angle exceeded (lookahead)");
+			break;
 		}
 
 		_quadchute_requested = true;
@@ -320,6 +334,9 @@ VtolAttitudeControl::parameters_update()
 	/* maximum roll angle (QuadChute) */
 	param_get(_params_handles.fw_qc_max_roll, &l);
 	_params.fw_qc_max_roll = l;
+
+	param_get(_params_handles.vt_fw_qc_p_la, &_params.vt_fw_qc_p_la);
+	param_get(_params_handles.vt_fw_qc_r_la, &_params.vt_fw_qc_r_la);
 
 	param_get(_params_handles.front_trans_time_openloop, &_params.front_trans_time_openloop);
 
@@ -471,6 +488,7 @@ VtolAttitudeControl::Run()
 
 		_tecs_status_sub.update(&_tecs_status);
 		_land_detected_sub.update(&_land_detected);
+		_vehicle_angular_velocity_sub.update(&_vehicle_angular_velocity);
 		action_request_poll();
 		vehicle_cmd_poll();
 
@@ -548,12 +566,14 @@ VtolAttitudeControl::Run()
 		_vehicle_thrust_setpoint1_pub.publish(_thrust_setpoint_1);
 
 		// Advertise/Publish vtol vehicle status
-		_vtol_vehicle_status.timestamp = hrt_absolute_time();
 		_vtol_vehicle_status.airspeed_filtered = get_filtered_airspeed();
 		_vtol_vehicle_status.mc_weights[0] = _vtol_type->_mc_roll_weight;
 		_vtol_vehicle_status.mc_weights[1] = _vtol_type->_mc_pitch_weight;
 		_vtol_vehicle_status.mc_weights[2] = _vtol_type->_mc_yaw_weight;
 		_vtol_vehicle_status.mc_weights[3] = _vtol_type->_mc_throttle_weight;
+		_vtol_vehicle_status.lookahead_pitch = _vtol_type->get_qc_lookahead_pitch();
+		_vtol_vehicle_status.lookahead_roll = _vtol_type->get_qc_lookahead_roll();
+		_vtol_vehicle_status.timestamp = hrt_absolute_time();
 		_vtol_vehicle_status_pub.publish(_vtol_vehicle_status);
 	}
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -85,6 +85,7 @@
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_thrust_setpoint.h>
 #include <uORB/topics/vehicle_torque_setpoint.h>
+#include <uORB/topics/vehicle_angular_velocity.h>
 #include "standard.h"
 #include "tailsitter.h"
 #include "tiltrotor.h"
@@ -105,6 +106,8 @@ public:
 		LargeAltError,
 		MaximumPitchExceeded,
 		MaximumRollExceeded,
+		MaximumPitchExceededLookahead,
+		MaximumRollExceededLookahead,
 	};
 
 	VtolAttitudeControl();
@@ -149,6 +152,7 @@ public:
 	struct vehicle_torque_setpoint_s 		*get_torque_setpoint_1() {return &_torque_setpoint_1;}
 	struct vehicle_thrust_setpoint_s 		*get_thrust_setpoint_0() {return &_thrust_setpoint_0;}
 	struct vehicle_thrust_setpoint_s 		*get_thrust_setpoint_1() {return &_thrust_setpoint_1;}
+	struct vehicle_angular_velocity_s	*get_angular_velocity() { return &_vehicle_angular_velocity; }
 
 	/**
 	 * @brief Low pass filtered airspeed to be used during transition
@@ -182,6 +186,7 @@ private:
 	uORB::Subscription _v_control_mode_sub{ORB_ID(vehicle_control_mode)};	//vehicle control mode subscription
 	uORB::Subscription _vehicle_cmd_sub{ORB_ID(vehicle_command)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+	uORB::Subscription _vehicle_angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};
 
 	uORB::Publication<actuator_controls_s>		_actuators_0_pub{ORB_ID(actuator_controls_0)};		//input for the mixer (roll,pitch,yaw,thrust)
 	uORB::Publication<actuator_controls_s>		_actuators_1_pub{ORB_ID(actuator_controls_1)};
@@ -221,6 +226,7 @@ private:
 	vehicle_local_position_s		_local_pos{};
 	vehicle_local_position_setpoint_s	_local_pos_sp{};
 	vtol_vehicle_status_s 			_vtol_vehicle_status{};
+	vehicle_angular_velocity_s		_vehicle_angular_velocity{};
 
 	float _air_density{CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C};	// [kg/m^3]
 
@@ -236,6 +242,8 @@ private:
 		param_t fw_alt_err;
 		param_t fw_qc_max_pitch;
 		param_t fw_qc_max_roll;
+		param_t vt_fw_qc_p_la;
+		param_t vt_fw_qc_r_la;
 		param_t front_trans_time_openloop;
 		param_t front_trans_time_min;
 		param_t front_trans_duration;

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -263,6 +263,42 @@ PARAM_DEFINE_INT32(VT_FW_QC_P, 0);
 PARAM_DEFINE_INT32(VT_FW_QC_R, 0);
 
 /**
+ * Quad-chute pitch lookahead time
+ *
+ * Predicts future pitch attitude from angular velocity to trigger quadchute before pitch limits
+ * are exceeded, allowing reaction to a flip before it becomes unrecoverable.
+ * Increasing this parameter trades off false positives for faster reaction.
+ * Should not be much larger than the pitch time constant, otherwise it will trigger from
+ * normal pitching maneuvers. Set to 0 to disable.
+ *
+ * @unit s
+ * @min 0.0
+ * @max 1.0
+ * @decimal 2
+ * @increment 0.01
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_FW_QC_P_LA, 0.0f);
+
+/**
+ * Quad-chute roll lookahead time
+ *
+ * Predicts future roll attitude from angular velocity to trigger quadchute before roll limits
+ * are exceeded, allowing reaction to a flip before it becomes unrecoverable.
+ * Increasing this parameter trades off false positives for faster reaction.
+ * Should not be much larger than the roll time constant, otherwise it will trigger from
+ * normal rolling maneuvers. Set to 0 to disable.
+ *
+ * @unit s
+ * @min 0.0
+ * @max 1.0
+ * @decimal 2
+ * @increment 0.01
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_FW_QC_R_LA, 0.0f);
+
+/**
  * Airspeed less front transition time (open loop)
  *
  * The duration of the front transition when there is no airspeed feedback available.

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -158,8 +158,10 @@ void VtolType::update_mc_state()
 	_mc_pitch_weight = 1.0f;
 	_mc_yaw_weight = 1.0f;
 	_mc_throttle_weight = 1.0f;
-	_qc_lookahead_pitch = 0.0f;
-	_qc_lookahead_roll = 0.0f;
+	_qc_lookahead_pitch_euler = 0.0f;
+	_qc_lookahead_roll_euler = 0.0f;
+	_qc_lookahead_pitch_quat = 0.0f;
+	_qc_lookahead_roll_quat = 0.0f;
 }
 
 void VtolType::update_fw_state()
@@ -261,23 +263,54 @@ void VtolType::update_qc_lookahead_angles()
 	const float q = _vehicle_angular_velocity->xyz[1];
 	const float r = _vehicle_angular_velocity->xyz[2];
 
+	// Validate angular velocity inputs
 	if (!PX4_ISFINITE(p) || !PX4_ISFINITE(q) || !PX4_ISFINITE(r)) {
-		_qc_lookahead_pitch = NAN;
-		_qc_lookahead_roll = NAN;
+		_qc_lookahead_pitch_euler = NAN;
+		_qc_lookahead_roll_euler = NAN;
+		_qc_lookahead_pitch_quat = NAN;
+		_qc_lookahead_roll_quat = NAN;
 		return;
 	}
 
 	const Eulerf euler(Quatf(_v_att->q));
 	const float phi = euler.phi();
-
 	constexpr float MAX_PITCH_FOR_TAN = math::radians(89.f);
 	const float theta = math::constrain(euler.theta(), -MAX_PITCH_FOR_TAN, MAX_PITCH_FOR_TAN);
 
+	// ============================================================
+	// EULER-BASED PREDICTION (original method, kept for comparison)
+	// ============================================================
 	const float euler_pitch_rate = q * cosf(phi) - r * sinf(phi);
 	const float euler_roll_rate = p + (q * sinf(phi) + r * cosf(phi)) * tanf(theta);
 
-	_qc_lookahead_pitch = euler.theta() + _params->vt_fw_qc_p_la * euler_pitch_rate;
-	_qc_lookahead_roll = euler.phi() + _params->vt_fw_qc_r_la * euler_roll_rate;
+	_qc_lookahead_pitch_euler = euler.theta() + _params->vt_fw_qc_p_la * euler_pitch_rate;
+	_qc_lookahead_roll_euler = euler.phi() + _params->vt_fw_qc_r_la * euler_roll_rate;
+
+	// ============================================================
+	// QUATERNION-BASED PREDICTION (new method for triggering)
+	// ============================================================
+	const Quatf q_current(_v_att->q);
+	const Vector3f w_B(p, q, r);
+
+	// Predict pitch with pitch lookahead time
+	if (_params->vt_fw_qc_p_la > FLT_EPSILON) {
+		const Quatf dq_pitch = Quatf::expq(0.5f * _params->vt_fw_qc_p_la * w_B);
+		const Quatf q_pred_pitch = (q_current * dq_pitch).normalized();
+		_qc_lookahead_pitch_quat = Eulerf(q_pred_pitch).theta();
+
+	} else {
+		_qc_lookahead_pitch_quat = euler.theta();
+	}
+
+	// Predict roll with roll lookahead time
+	if (_params->vt_fw_qc_r_la > FLT_EPSILON) {
+		const Quatf dq_roll = Quatf::expq(0.5f * _params->vt_fw_qc_r_la * w_B);
+		const Quatf q_pred_roll = (q_current * dq_roll).normalized();
+		_qc_lookahead_roll_quat = Eulerf(q_pred_roll).phi();
+
+	} else {
+		_qc_lookahead_roll_quat = euler.phi();
+	}
 }
 
 void VtolType::check_quadchute_condition()
@@ -354,16 +387,16 @@ void VtolType::check_quadchute_condition()
 			}
 		}
 
-		// fixed-wing maximum pitch angle (lookahead)
-		if (PX4_ISFINITE(_qc_lookahead_pitch) && _params->fw_qc_max_pitch > 0) {
-			if (fabsf(_qc_lookahead_pitch) > fabsf(math::radians(_params->fw_qc_max_pitch))) {
+		// fixed-wing maximum pitch angle (lookahead) - USE EULER METHOD
+		if (PX4_ISFINITE(_qc_lookahead_pitch_euler) && _params->fw_qc_max_pitch > 0) {
+			if (fabsf(_qc_lookahead_pitch_euler) > fabsf(math::radians(_params->fw_qc_max_pitch))) {
 				_attc->quadchute(VtolAttitudeControl::QuadchuteReason::MaximumPitchExceededLookahead);
 			}
 		}
 
-		// fixed-wing maximum roll angle (lookahead)
-		if (PX4_ISFINITE(_qc_lookahead_roll) && _params->fw_qc_max_roll > 0) {
-			if (fabsf(_qc_lookahead_roll) > fabsf(math::radians(_params->fw_qc_max_roll))) {
+		// fixed-wing maximum roll angle (lookahead) - USE EULER METHOD
+		if (PX4_ISFINITE(_qc_lookahead_roll_euler) && _params->fw_qc_max_roll > 0) {
+			if (fabsf(_qc_lookahead_roll_euler) > fabsf(math::radians(_params->fw_qc_max_roll))) {
 				_attc->quadchute(VtolAttitudeControl::QuadchuteReason::MaximumRollExceededLookahead);
 			}
 		}

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -74,6 +74,7 @@ VtolType::VtolType(VtolAttitudeControl *att_controller) :
 	_airspeed_validated = _attc->get_airspeed();
 	_tecs_status = _attc->get_tecs_status();
 	_land_detected = _attc->get_land_detected();
+	_vehicle_angular_velocity = _attc->get_angular_velocity();
 	_params = _attc->get_params();
 
 	for (auto &pwm_max : _max_mc_pwm_values.values) {
@@ -157,6 +158,8 @@ void VtolType::update_mc_state()
 	_mc_pitch_weight = 1.0f;
 	_mc_yaw_weight = 1.0f;
 	_mc_throttle_weight = 1.0f;
+	_qc_lookahead_pitch = 0.0f;
+	_qc_lookahead_roll = 0.0f;
 }
 
 void VtolType::update_fw_state()
@@ -252,6 +255,31 @@ bool VtolType::can_transition_on_ground()
 	return !_v_control_mode->flag_armed || _land_detected->landed;
 }
 
+void VtolType::update_qc_lookahead_angles()
+{
+	const float p = _vehicle_angular_velocity->xyz[0];
+	const float q = _vehicle_angular_velocity->xyz[1];
+	const float r = _vehicle_angular_velocity->xyz[2];
+
+	if (!PX4_ISFINITE(p) || !PX4_ISFINITE(q) || !PX4_ISFINITE(r)) {
+		_qc_lookahead_pitch = NAN;
+		_qc_lookahead_roll = NAN;
+		return;
+	}
+
+	const Eulerf euler(Quatf(_v_att->q));
+	const float phi = euler.phi();
+
+	constexpr float MAX_PITCH_FOR_TAN = math::radians(89.f);
+	const float theta = math::constrain(euler.theta(), -MAX_PITCH_FOR_TAN, MAX_PITCH_FOR_TAN);
+
+	const float euler_pitch_rate = q * cosf(phi) - r * sinf(phi);
+	const float euler_roll_rate = p + (q * sinf(phi) + r * cosf(phi)) * tanf(theta);
+
+	_qc_lookahead_pitch = euler.theta() + _params->vt_fw_qc_p_la * euler_pitch_rate;
+	_qc_lookahead_roll = euler.phi() + _params->vt_fw_qc_r_la * euler_roll_rate;
+}
+
 void VtolType::check_quadchute_condition()
 {
 	if (_attc->get_transition_command() == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC && _attc->get_immediate_transition()
@@ -263,6 +291,8 @@ void VtolType::check_quadchute_condition()
 	} else {
 		_quadchute_command_treated = false;
 	}
+
+	update_qc_lookahead_angles();
 
 	if (!_tecs_running) {
 		// reset the filtered height rate and heigh rate setpoint if TECS is not running
@@ -321,6 +351,20 @@ void VtolType::check_quadchute_condition()
 
 			if (fabsf(euler.phi()) > fabsf(math::radians(_params->fw_qc_max_roll))) {
 				_attc->quadchute(VtolAttitudeControl::QuadchuteReason::MaximumRollExceeded);
+			}
+		}
+
+		// fixed-wing maximum pitch angle (lookahead)
+		if (PX4_ISFINITE(_qc_lookahead_pitch) && _params->fw_qc_max_pitch > 0) {
+			if (fabsf(_qc_lookahead_pitch) > fabsf(math::radians(_params->fw_qc_max_pitch))) {
+				_attc->quadchute(VtolAttitudeControl::QuadchuteReason::MaximumPitchExceededLookahead);
+			}
+		}
+
+		// fixed-wing maximum roll angle (lookahead)
+		if (PX4_ISFINITE(_qc_lookahead_roll) && _params->fw_qc_max_roll > 0) {
+			if (fabsf(_qc_lookahead_roll) > fabsf(math::radians(_params->fw_qc_max_roll))) {
+				_attc->quadchute(VtolAttitudeControl::QuadchuteReason::MaximumRollExceededLookahead);
 			}
 		}
 	}

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -216,8 +216,13 @@ public:
 	*/
 	float getOpenLoopFrontTransitionTime() const;
 
-	float get_qc_lookahead_pitch() const { return _qc_lookahead_pitch; }
-	float get_qc_lookahead_roll() const { return _qc_lookahead_roll; }
+	// Euler-based getters
+	float get_qc_lookahead_pitch_euler() const { return _qc_lookahead_pitch_euler; }
+	float get_qc_lookahead_roll_euler() const { return _qc_lookahead_roll_euler; }
+
+	// Quaternion-based getters
+	float get_qc_lookahead_pitch_quat() const { return _qc_lookahead_pitch_quat; }
+	float get_qc_lookahead_roll_quat() const { return _qc_lookahead_roll_quat; }
 
 	virtual void parameters_update() = 0;
 
@@ -257,8 +262,14 @@ public:
 	float _mc_pitch_weight = 1.0f;	// weight for multicopter attitude controller pitch output
 	float _mc_yaw_weight = 1.0f;	// weight for multicopter attitude controller yaw output
 	float _mc_throttle_weight = 1.0f;	// weight for multicopter throttle command. Used to avoid
-	float _qc_lookahead_pitch = 0.0f;
-	float _qc_lookahead_roll = 0.0f;
+
+	// Euler-based lookahead (used for triggering)
+	float _qc_lookahead_pitch_euler = 0.0f;
+	float _qc_lookahead_roll_euler = 0.0f;
+
+	// Quaternion-based lookahead (for comparison)
+	float _qc_lookahead_pitch_quat = 0.0f;
+	float _qc_lookahead_roll_quat = 0.0f;
 
 	// motors spinning up or cutting too fast when doing transitions.
 	float _thrust_transition = 0.0f;	// thrust value applied during a front transition (tailsitter & tiltrotor only)

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -57,6 +57,8 @@ struct Params {
 	float fw_alt_err;			// maximum negative altitude error for FW mode (Adaptive QuadChute)
 	float fw_qc_max_pitch;		// maximum pitch angle FW mode (QuadChute)
 	float fw_qc_max_roll;		// maximum roll angle FW mode (QuadChute)
+	float vt_fw_qc_p_la;		// quadchute pitch lookahead time
+	float vt_fw_qc_r_la;		// quadchute roll lookahead time
 	float front_trans_time_openloop;
 	float front_trans_time_min;
 	float front_trans_duration;
@@ -179,6 +181,7 @@ public:
 	 * Checks for fixed-wing failsafe condition and issues abort request if needed.
 	 */
 	void check_quadchute_condition();
+	void update_qc_lookahead_angles();
 
 	/**
 	 * Returns true if we're allowed to do a mode transition on the ground.
@@ -213,6 +216,9 @@ public:
 	*/
 	float getOpenLoopFrontTransitionTime() const;
 
+	float get_qc_lookahead_pitch() const { return _qc_lookahead_pitch; }
+	float get_qc_lookahead_roll() const { return _qc_lookahead_roll; }
+
 	virtual void parameters_update() = 0;
 
 	VtolAttitudeControl *_attc;
@@ -235,6 +241,7 @@ public:
 	struct airspeed_validated_s 				*_airspeed_validated;					// airspeed
 	struct tecs_status_s				*_tecs_status;
 	struct vehicle_land_detected_s			*_land_detected;
+	struct vehicle_angular_velocity_s		*_vehicle_angular_velocity;	// angular velocity for quadchute lookahead
 
 	struct vehicle_torque_setpoint_s 		*_torque_setpoint_0;
 	struct vehicle_torque_setpoint_s 		*_torque_setpoint_1;
@@ -250,6 +257,8 @@ public:
 	float _mc_pitch_weight = 1.0f;	// weight for multicopter attitude controller pitch output
 	float _mc_yaw_weight = 1.0f;	// weight for multicopter attitude controller yaw output
 	float _mc_throttle_weight = 1.0f;	// weight for multicopter throttle command. Used to avoid
+	float _qc_lookahead_pitch = 0.0f;
+	float _qc_lookahead_roll = 0.0f;
 
 	// motors spinning up or cutting too fast when doing transitions.
 	float _thrust_transition = 0.0f;	// thrust value applied during a front transition (tailsitter & tiltrotor only)


### PR DESCRIPTION
For NX02 testing, backport of https://github.com/aviant-tech/PX4-Autopilot/compare/aviant/1.13-to-1.15...aviant-tech:PX4-Autopilot:aviant/qc-lookahead?expand=1