### PR TITLE
GNSS-denied testing 1.15

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -182,6 +182,12 @@ param set-default SYS_FAILURE_EN 1
 # does not go below 50% by default, but failure injection can trigger failsafes.
 param set-default COM_LOW_BAT_ACT 2
 
+# Enable GNSS-denied EKF instances for testing (requires multi-instance EKF2)
+if [ "$PX4_EKF2_GNSS_DENIED" = "1" ]; then
+	param set SENS_IMU_MODE 0
+	param set EKF2_GNSS_DENIED 1
+fi
+
 
 # Adapt timeout parameters if simulation runs faster or slower than realtime.
 if [ -n "$PX4_SIM_SPEED_FACTOR" ]; then

--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -8,7 +8,7 @@ jinja2>=2.8
 jsonschema
 kconfiglib
 lxml
-matplotlib>=3.0.*
+matplotlib>=3.0
 numpy>=1.13
 nunavut>=1.1.0
 packaging

--- a/msg/EstimatorStatus.msg
+++ b/msg/EstimatorStatus.msg
@@ -128,7 +128,8 @@ uint32 mag_device_id
 uint8 pos_est_mode
 uint8 POS_EST_MODE_NORMAL = 0
 uint8 POS_EST_MODE_VISION_DENIED = 1
-uint8 POS_EST_MODE_GNSS_DENIED = 2
+uint8 POS_EST_MODE_GNSS_DENIED_ARMED = 2
+uint8 POS_EST_MODE_GNSS_DENIED_ALWAYS = 3
 
 # legacy local position estimator (LPE) flags
 uint8 health_flags		# Bitmask to indicate sensor health states (vel, pos, hgt)

--- a/msg/EstimatorStatus.msg
+++ b/msg/EstimatorStatus.msg
@@ -124,6 +124,12 @@ uint32 gyro_device_id
 uint32 baro_device_id
 uint32 mag_device_id
 
+# Position estimation mode
+uint8 pos_est_mode
+uint8 POS_EST_MODE_NORMAL = 0
+uint8 POS_EST_MODE_VISION_DENIED = 1
+uint8 POS_EST_MODE_GNSS_DENIED = 2
+
 # legacy local position estimator (LPE) flags
 uint8 health_flags		# Bitmask to indicate sensor health states (vel, pos, hgt)
 uint8 timeout_flags		# Bitmask to indicate timeout flags (vel, pos, hgt)

--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -334,6 +334,7 @@ void Ekf::resetGlobalPosToExternalObservation(double lat_deg, double lon_deg, fl
 {
 
 	if (!_pos_ref.isInitialized()) {
+		ECL_WARN("EXTPOS: pos_ref not initialized, cannot reset");
 		return;
 	}
 

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -420,6 +420,8 @@ public:
 	void collect_gps(const gnssSample &gps);
 
 	// set minimum continuous period without GPS fail required to mark a healthy GPS status
+	void setDisableFakePosFusion(bool disable) { _fake_pos_fusion_disabled = disable; }
+
 	void set_min_required_gps_health_time(uint32_t time_us) { _min_gps_health_time_us = time_us; }
 	void set_min_required_gps_recovery_time(uint32_t time_us) { _min_gps_recovery_time_us = time_us; }
 
@@ -631,6 +633,8 @@ private:
 #if defined(CONFIG_EKF2_SIDESLIP)
 	estimator_aid_source1d_s _aid_src_sideslip{};
 #endif // CONFIG_EKF2_SIDESLIP
+
+	bool _fake_pos_fusion_disabled{false};
 
 	estimator_aid_source2d_s _aid_src_fake_pos{};
 	estimator_aid_source1d_s _aid_src_fake_hgt{};

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -419,9 +419,9 @@ public:
 #if defined(CONFIG_EKF2_GNSS)
 	void collect_gps(const gnssSample &gps);
 
-	// set minimum continuous period without GPS fail required to mark a healthy GPS status
 	void setDisableFakePosFusion(bool disable) { _fake_pos_fusion_disabled = disable; }
 
+	// set minimum continuous period without GPS fail required to mark a healthy GPS status
 	void set_min_required_gps_health_time(uint32_t time_us) { _min_gps_health_time_us = time_us; }
 	void set_min_required_gps_recovery_time(uint32_t time_us) { _min_gps_recovery_time_us = time_us; }
 

--- a/src/modules/ekf2/EKF/fake_height_control.cpp
+++ b/src/modules/ekf2/EKF/fake_height_control.cpp
@@ -40,6 +40,11 @@
 
 void Ekf::controlFakeHgtFusion()
 {
+	if (_fake_pos_fusion_disabled) {
+		stopFakeHgtFusion();
+		return;
+	}
+
 	auto &aid_src = _aid_src_fake_hgt;
 
 	// If we aren't doing any aiding, fake position measurements at the last known vertical position to constrain drift

--- a/src/modules/ekf2/EKF/fake_pos_control.cpp
+++ b/src/modules/ekf2/EKF/fake_pos_control.cpp
@@ -40,6 +40,11 @@
 
 void Ekf::controlFakePosFusion()
 {
+	if (_fake_pos_fusion_disabled) {
+		stopFakePosFusion();
+		return;
+	}
+
 	auto &aid_src = _aid_src_fake_pos;
 
 	// If we aren't doing any aiding, fake position measurements at the last known position to constrain drift

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -763,8 +763,9 @@ void EKF2::Run()
 
 		// Skip GPS updates in GNSS-denied mode:
 		// - GNSS_DENIED_ARMED: skip only when armed (allows GPS for initialization)
-		// - GNSS_DENIED_ALWAYS: skip at all times
-		if (!(_pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED_ALWAYS
+		// - GNSS_DENIED_ALWAYS: skip after NED origin is initialized (need first fix for reference)
+		if (!((_pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED_ALWAYS
+		       && _ekf.global_origin_valid())
 		      || (_is_armed && _pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED_ARMED))) {
 			UpdateGpsSample(ekf2_timestamps);
 # if defined(CONFIG_EKF2_GNSS_YAW)

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -41,7 +41,7 @@ using matrix::Quatf;
 using matrix::Vector3f;
 
 static constexpr float kDefaultExternalPosAccuracy = 50.0f; // [m]
-static constexpr float kMaxDelaySecondsExternalPosMeasurement = 15.0f; // [s]
+static constexpr uint64_t kMaxAgeExternalPosMeasurement = 15_s;
 
 pthread_mutex_t ekf2_module_mutex = PTHREAD_MUTEX_INITIALIZER;
 static px4::atomic<EKF2 *> _objects[EKF2_MAX_INSTANCES] {};
@@ -485,9 +485,24 @@ void EKF2::Run()
 				if ((_ekf.control_status_flags().wind_dead_reckoning || _ekf.control_status_flags().inertial_dead_reckoning) &&
 				    PX4_ISFINITE(vehicle_command.param2) && PX4_ISFINITE(vehicle_command.param5) && PX4_ISFINITE(vehicle_command.param6)) {
 
-					const float measurement_delay_seconds = math::constrain(vehicle_command.param2, 0.0f,
-										kMaxDelaySecondsExternalPosMeasurement);
-					const uint64_t timestamp_observation = vehicle_command.timestamp - measurement_delay_seconds * 1_s;
+					// Trust the transmission_time from the message to be in flight controller time, ignoring
+					// processing_time.
+					// Cast to double first to avoid unnecessary precission loss
+					const uint64_t cmd_timestamp = static_cast<uint64_t>(static_cast<double>(vehicle_command.param1) * 1_s);
+					bool cmd_timestamp_valid{true};
+
+					// Basic validation of the timestamp
+					if (!PX4_ISFINITE(vehicle_command.param1)) {
+						cmd_timestamp_valid = false;
+					}
+
+					if (cmd_timestamp > hrt_absolute_time()) {
+						cmd_timestamp_valid = false; // Cannot be into the future
+					}
+
+					if (cmd_timestamp < math::max(kMaxAgeExternalPosMeasurement, hrt_absolute_time() - kMaxAgeExternalPosMeasurement)) {
+						cmd_timestamp_valid = false; // Too old
+					}
 
 					float accuracy = kDefaultExternalPosAccuracy;
 
@@ -496,8 +511,12 @@ void EKF2::Run()
 					}
 
 					// TODO add check for lat and long validity
-					_ekf.resetGlobalPosToExternalObservation(vehicle_command.param5, vehicle_command.param6,
-							accuracy, timestamp_observation);
+					if (cmd_timestamp_valid) {
+						_ekf.resetGlobalPosToExternalObservation(vehicle_command.param5, vehicle_command.param6,
+								accuracy, cmd_timestamp);
+					}
+
+
 				}
 			}
 		}

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -235,8 +235,10 @@ EKF2::~EKF2()
 }
 
 #if defined(CONFIG_EKF2_MULTI_INSTANCE)
-bool EKF2::multi_init(int imu, int mag)
+bool EKF2::multi_init(int imu, int mag, uint8_t pos_est_mode)
 {
+	_pos_est_mode = pos_est_mode;
+
 	// advertise all topics to ensure consistent uORB instance numbering
 	_estimator_event_flags_pub.advertise();
 	_estimator_innovation_test_ratios_pub.advertise();
@@ -707,11 +709,27 @@ void EKF2::Run()
 #if defined(CONFIG_EKF2_OPTICAL_FLOW)
 		UpdateFlowSample(ekf2_timestamps);
 #endif // CONFIG_EKF2_OPTICAL_FLOW
+
+		// Update armed state early for GNSS-denied mode check (don't consume update flag)
+		{
+			vehicle_status_s vehicle_status;
+
+			if (_status_sub.copy(&vehicle_status)) {
+				_is_armed = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
+			}
+		}
+
 #if defined(CONFIG_EKF2_GNSS)
-		UpdateGpsSample(ekf2_timestamps);
+
+		// Skip GPS updates when armed in GNSS-denied mode
+		// Allow GPS fusion while disarmed for proper initialization
+		if (!(_is_armed && _pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED)) {
+			UpdateGpsSample(ekf2_timestamps);
 # if defined(CONFIG_EKF2_GNSS_YAW)
-		updateGnssHeadingSample(ekf2_timestamps);
+			updateGnssHeadingSample(ekf2_timestamps);
 # endif //CONFIG_EKF2_GNSS_YAW
+		}
+
 #endif // CONFIG_EKF2_GNSS
 #if defined(CONFIG_EKF2_MAGNETOMETER)
 		UpdateMagSample(ekf2_timestamps);
@@ -1865,6 +1883,8 @@ void EKF2::PublishStatus(const hrt_abstime &timestamp)
 			    status.mag_strength_ref_gs);
 #endif // CONFIG_EKF2_MAGNETOMETER
 
+	status.pos_est_mode = _pos_est_mode;
+
 	status.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 	_estimator_status_pub.publish(status);
 }
@@ -2587,8 +2607,11 @@ void EKF2::UpdateSystemFlagsSample(ekf2_timestamps_s &ekf2_timestamps)
 		if (_status_sub.copy(&vehicle_status)
 		    && (ekf2_timestamps.timestamp < vehicle_status.timestamp + 3_s)) {
 
+			// Track armed state for GNSS-denied mode
+			_is_armed = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
+
 			// initially set in_air from arming_state (will be overridden if land detector is available)
-			flags.in_air = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
+			flags.in_air = _is_armed;
 
 			// let the EKF know if the vehicle motion is that of a fixed wing (forward flight only relative to wind)
 			flags.is_fixed_wing = (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING);
@@ -2755,9 +2778,22 @@ int EKF2::task_spawn(int argc, char *argv[])
 	int32_t sens_imu_mode = 1;
 	param_get(param_find("SENS_IMU_MODE"), &sens_imu_mode);
 
+	int32_t ekf2_gnss_denied = 0;
+
 	if (sens_imu_mode == 0) {
 		// ekf selector requires SENS_IMU_MODE = 0
 		multi_mode = true;
+
+		// Check if GNSS-denied estimator instances are enabled
+		param_get(param_find("EKF2_GNSS_DENIED"), &ekf2_gnss_denied);
+
+		if (ekf2_gnss_denied < 0 || ekf2_gnss_denied > 1) {
+			const int32_t ekf2_gnss_denied_limited = math::constrain(ekf2_gnss_denied, static_cast<int32_t>(0),
+					static_cast<int32_t>(1));
+			PX4_WARN("EKF2_GNSS_DENIED limited %" PRId32 " -> %" PRId32, ekf2_gnss_denied, ekf2_gnss_denied_limited);
+			param_set_no_notification(param_find("EKF2_GNSS_DENIED"), &ekf2_gnss_denied_limited);
+			ekf2_gnss_denied = ekf2_gnss_denied_limited;
+		}
 
 		// IMUs (1 - MAX_NUM_IMUS supported)
 		param_get(param_find("EKF2_MULTI_IMU"), &imu_instances);
@@ -2820,13 +2856,17 @@ int EKF2::task_spawn(int argc, char *argv[])
 		}
 
 		const hrt_abstime time_started = hrt_absolute_time();
-		const int multi_instances = math::min(imu_instances * mag_instances, static_cast<int32_t>(EKF2_MAX_INSTANCES));
+		const uint8_t num_pos_est_modes = (ekf2_gnss_denied == 1) ? 2 : 1;
+		const int multi_instances = math::min(imu_instances * mag_instances * num_pos_est_modes,
+						      static_cast<int32_t>(EKF2_MAX_INSTANCES));
 		int multi_instances_allocated = 0;
 
 		// allocate EKF2 instances until all found or arming
 		uORB::SubscriptionData<vehicle_status_s> vehicle_status_sub{ORB_ID(vehicle_status)};
 
-		bool ekf2_instance_created[MAX_NUM_IMUS][MAX_NUM_MAGS] {}; // IMUs * mags
+		// Track instance creation for each IMU/MAG/mode combination
+		// mode 0 = normal, mode 1 = GNSS-denied
+		bool ekf2_instance_created[MAX_NUM_IMUS][MAX_NUM_MAGS][2] {}; // IMUs * mags * pos_est_modes
 
 		while ((multi_instances_allocated < multi_instances)
 		       && (vehicle_status_sub.get().arming_state != vehicle_status_s::ARMING_STATE_ARMED)
@@ -2835,51 +2875,59 @@ int EKF2::task_spawn(int argc, char *argv[])
 
 			vehicle_status_sub.update();
 
-			for (uint8_t mag = 0; mag < mag_instances; mag++) {
-				uORB::SubscriptionData<vehicle_magnetometer_s> vehicle_mag_sub{ORB_ID(vehicle_magnetometer), mag};
+			for (uint8_t mode = 0; mode < num_pos_est_modes; mode++) {
+				uint8_t pos_est_mode = estimator_status_s::POS_EST_MODE_NORMAL;
 
-				for (uint8_t imu = 0; imu < imu_instances; imu++) {
+				if (mode == 1) {
+					pos_est_mode = estimator_status_s::POS_EST_MODE_GNSS_DENIED;
+				}
 
-					uORB::SubscriptionData<vehicle_imu_s> vehicle_imu_sub{ORB_ID(vehicle_imu), imu};
-					vehicle_mag_sub.update();
+				for (uint8_t mag = 0; mag < mag_instances; mag++) {
+					uORB::SubscriptionData<vehicle_magnetometer_s> vehicle_mag_sub{ORB_ID(vehicle_magnetometer), mag};
 
-					// Mag & IMU data must be valid, first mag can be ignored initially
-					if ((vehicle_mag_sub.advertised() || mag == 0) && (vehicle_imu_sub.advertised())) {
+					for (uint8_t imu = 0; imu < imu_instances; imu++) {
 
-						if (!ekf2_instance_created[imu][mag]) {
-							EKF2 *ekf2_inst = new EKF2(true, px4::ins_instance_to_wq(imu), false);
+						uORB::SubscriptionData<vehicle_imu_s> vehicle_imu_sub{ORB_ID(vehicle_imu), imu};
+						vehicle_mag_sub.update();
 
-							if (ekf2_inst && ekf2_inst->multi_init(imu, mag)) {
-								int actual_instance = ekf2_inst->instance(); // match uORB instance numbering
+						// Mag & IMU data must be valid, first mag can be ignored initially
+						if ((vehicle_mag_sub.advertised() || mag == 0) && (vehicle_imu_sub.advertised())) {
 
-								if ((actual_instance >= 0) && (_objects[actual_instance].load() == nullptr)) {
-									_objects[actual_instance].store(ekf2_inst);
-									success = true;
-									multi_instances_allocated++;
-									ekf2_instance_created[imu][mag] = true;
+							if (!ekf2_instance_created[imu][mag][mode]) {
+								EKF2 *ekf2_inst = new EKF2(true, px4::ins_instance_to_wq(imu), false);
 
-									PX4_DEBUG("starting instance %d, IMU:%" PRIu8 " (%" PRIu32 "), MAG:%" PRIu8 " (%" PRIu32 ")", actual_instance,
-										  imu, vehicle_imu_sub.get().accel_device_id,
-										  mag, vehicle_mag_sub.get().device_id);
+								if (ekf2_inst && ekf2_inst->multi_init(imu, mag, pos_est_mode)) {
+									int actual_instance = ekf2_inst->instance(); // match uORB instance numbering
 
-									_ekf2_selector.load()->ScheduleNow();
+									if ((actual_instance >= 0) && (_objects[actual_instance].load() == nullptr)) {
+										_objects[actual_instance].store(ekf2_inst);
+										success = true;
+										multi_instances_allocated++;
+										ekf2_instance_created[imu][mag][mode] = true;
+
+										PX4_DEBUG("starting instance %d, IMU:%" PRIu8 " (%" PRIu32 "), MAG:%" PRIu8 " (%" PRIu32 "), mode:%" PRIu8,
+											  actual_instance, imu, vehicle_imu_sub.get().accel_device_id,
+											  mag, vehicle_mag_sub.get().device_id, pos_est_mode);
+
+										_ekf2_selector.load()->ScheduleNow();
+
+									} else {
+										PX4_ERR("instance numbering problem instance: %d", actual_instance);
+										delete ekf2_inst;
+										break;
+									}
 
 								} else {
-									PX4_ERR("instance numbering problem instance: %d", actual_instance);
-									delete ekf2_inst;
+									PX4_ERR("alloc and init failed imu: %" PRIu8 " mag:%" PRIu8 " mode:%" PRIu8, imu, mag, pos_est_mode);
+									px4_usleep(100000);
 									break;
 								}
-
-							} else {
-								PX4_ERR("alloc and init failed imu: %" PRIu8 " mag:%" PRIu8, imu, mag);
-								px4_usleep(100000);
-								break;
 							}
-						}
 
-					} else {
-						px4_usleep(1000); // give the sensors extra time to start
-						break;
+						} else {
+							px4_usleep(1000); // give the sensors extra time to start
+							break;
+						}
 					}
 				}
 			}

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -239,6 +239,11 @@ bool EKF2::multi_init(int imu, int mag, uint8_t pos_est_mode)
 {
 	_pos_est_mode = pos_est_mode;
 
+	if (_pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED_ARMED
+	    || _pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED_ALWAYS) {
+		_ekf.setDisableFakePosFusion(true);
+	}
+
 	// advertise all topics to ensure consistent uORB instance numbering
 	_estimator_event_flags_pub.advertise();
 	_estimator_innovation_test_ratios_pub.advertise();

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -484,6 +484,11 @@ void EKF2::Run()
 			}
 
 			if (vehicle_command.command == vehicle_command_s::VEHICLE_CMD_EXTERNAL_POSITION_ESTIMATE) {
+				PX4_INFO("%d - EXTERNAL_POSITION_ESTIMATE received: lat=%.6f lon=%.6f acc=%.2f t=%.3f",
+					 _instance,
+					 (double)vehicle_command.param5, (double)vehicle_command.param6,
+					 (double)vehicle_command.param3, (double)vehicle_command.param1);
+
 				if ((_ekf.control_status_flags().wind_dead_reckoning || _ekf.control_status_flags().inertial_dead_reckoning) &&
 				    PX4_ISFINITE(vehicle_command.param2) && PX4_ISFINITE(vehicle_command.param5) && PX4_ISFINITE(vehicle_command.param6)) {
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -494,9 +494,23 @@ void EKF2::Run()
 					 (double)vehicle_command.param5, (double)vehicle_command.param6,
 					 (double)vehicle_command.param3, (double)vehicle_command.param1);
 
-				if ((_ekf.control_status_flags().wind_dead_reckoning || _ekf.control_status_flags().inertial_dead_reckoning) &&
-				    PX4_ISFINITE(vehicle_command.param2) && PX4_ISFINITE(vehicle_command.param5) && PX4_ISFINITE(vehicle_command.param6)) {
+				const bool is_dead_reckoning = _ekf.control_status_flags().wind_dead_reckoning
+							       || _ekf.control_status_flags().inertial_dead_reckoning;
 
+				if (!is_dead_reckoning) {
+					PX4_INFO("%d - EXTPOS rejected: not dead reckoning (wind_dr=%u, inertial_dr=%u)",
+						 _instance,
+						 (unsigned)_ekf.control_status_flags().wind_dead_reckoning,
+						 (unsigned)_ekf.control_status_flags().inertial_dead_reckoning);
+
+				} else if (!PX4_ISFINITE(vehicle_command.param2) || !PX4_ISFINITE(vehicle_command.param5)
+					   || !PX4_ISFINITE(vehicle_command.param6)) {
+					PX4_WARN("%d - EXTPOS rejected: non-finite params (p2=%.6f p5=%.6f p6=%.6f)",
+						 _instance,
+						 (double)vehicle_command.param2, (double)vehicle_command.param5,
+						 (double)vehicle_command.param6);
+
+				} else {
 					// Trust the transmission_time from the message to be in flight controller time, ignoring
 					// processing_time.
 					// Cast to double first to avoid unnecessary precission loss
@@ -505,14 +519,21 @@ void EKF2::Run()
 
 					// Basic validation of the timestamp
 					if (!PX4_ISFINITE(vehicle_command.param1)) {
+						PX4_WARN("%d - EXTPOS rejected: non-finite timestamp (param1=%.6f)",
+							 _instance, (double)vehicle_command.param1);
 						cmd_timestamp_valid = false;
 					}
 
 					if (cmd_timestamp > hrt_absolute_time()) {
+						PX4_WARN("%d - EXTPOS rejected: timestamp in the future (cmd=%" PRIu64 " now=%" PRIu64 ")",
+							 _instance, cmd_timestamp, hrt_absolute_time());
 						cmd_timestamp_valid = false; // Cannot be into the future
 					}
 
 					if (cmd_timestamp < math::max(kMaxAgeExternalPosMeasurement, hrt_absolute_time() - kMaxAgeExternalPosMeasurement)) {
+						PX4_WARN("%d - EXTPOS rejected: timestamp too old (cmd=%" PRIu64 " now=%" PRIu64 " max_age=%" PRIu64 ")",
+							 _instance, cmd_timestamp, hrt_absolute_time(),
+							 static_cast<uint64_t>(kMaxAgeExternalPosMeasurement));
 						cmd_timestamp_valid = false; // Too old
 					}
 
@@ -532,10 +553,12 @@ void EKF2::Run()
 								accuracy,
 								cmd_timestamp
 							);
+
+						} else {
+							PX4_INFO("%d - EXTPOS rejected: not a GNSS-denied instance (pos_est_mode=%d)",
+								 _instance, _pos_est_mode);
 						}
 					}
-
-
 				}
 			}
 		}

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -514,8 +514,14 @@ void EKF2::Run()
 
 					// TODO add check for lat and long validity
 					if (cmd_timestamp_valid) {
-						_ekf.resetGlobalPosToExternalObservation(vehicle_command.param5, vehicle_command.param6,
-								accuracy, cmd_timestamp);
+						if (_pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED) {
+							_ekf.resetGlobalPosToExternalObservation(
+								vehicle_command.param5,
+								vehicle_command.param6,
+								accuracy,
+								cmd_timestamp
+							);
+						}
 					}
 
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -514,7 +514,8 @@ void EKF2::Run()
 
 					// TODO add check for lat and long validity
 					if (cmd_timestamp_valid) {
-						if (_pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED) {
+						if (_pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED_ARMED
+						    || _pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED_ALWAYS) {
 							_ekf.resetGlobalPosToExternalObservation(
 								vehicle_command.param5,
 								vehicle_command.param6,
@@ -727,9 +728,11 @@ void EKF2::Run()
 
 #if defined(CONFIG_EKF2_GNSS)
 
-		// Skip GPS updates when armed in GNSS-denied mode
-		// Allow GPS fusion while disarmed for proper initialization
-		if (!(_is_armed && _pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED)) {
+		// Skip GPS updates in GNSS-denied mode:
+		// - GNSS_DENIED_ARMED: skip only when armed (allows GPS for initialization)
+		// - GNSS_DENIED_ALWAYS: skip at all times
+		if (!(_pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED_ALWAYS
+		      || (_is_armed && _pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED_ARMED))) {
 			UpdateGpsSample(ekf2_timestamps);
 # if defined(CONFIG_EKF2_GNSS_YAW)
 			updateGnssHeadingSample(ekf2_timestamps);
@@ -2784,7 +2787,12 @@ int EKF2::task_spawn(int argc, char *argv[])
 	int32_t sens_imu_mode = 1;
 	param_get(param_find("SENS_IMU_MODE"), &sens_imu_mode);
 
-	int32_t ekf2_gnss_denied = 0;
+	// EKF2_GNSS_DENIED parameter values
+	static constexpr int32_t EKF2_GNSS_DENIED_DISABLED = 0;
+	// EKF2_GNSS_DENIED_ARMED = 1 (mapped to POS_EST_MODE_GNSS_DENIED_ARMED)
+	static constexpr int32_t EKF2_GNSS_DENIED_ALWAYS   = 2;
+
+	int32_t ekf2_gnss_denied = EKF2_GNSS_DENIED_DISABLED;
 
 	if (sens_imu_mode == 0) {
 		// ekf selector requires SENS_IMU_MODE = 0
@@ -2793,9 +2801,9 @@ int EKF2::task_spawn(int argc, char *argv[])
 		// Check if GNSS-denied estimator instances are enabled
 		param_get(param_find("EKF2_GNSS_DENIED"), &ekf2_gnss_denied);
 
-		if (ekf2_gnss_denied < 0 || ekf2_gnss_denied > 1) {
-			const int32_t ekf2_gnss_denied_limited = math::constrain(ekf2_gnss_denied, static_cast<int32_t>(0),
-					static_cast<int32_t>(1));
+		if (ekf2_gnss_denied < EKF2_GNSS_DENIED_DISABLED || ekf2_gnss_denied > EKF2_GNSS_DENIED_ALWAYS) {
+			const int32_t ekf2_gnss_denied_limited = math::constrain(ekf2_gnss_denied, EKF2_GNSS_DENIED_DISABLED,
+					EKF2_GNSS_DENIED_ALWAYS);
 			PX4_WARN("EKF2_GNSS_DENIED limited %" PRId32 " -> %" PRId32, ekf2_gnss_denied, ekf2_gnss_denied_limited);
 			param_set_no_notification(param_find("EKF2_GNSS_DENIED"), &ekf2_gnss_denied_limited);
 			ekf2_gnss_denied = ekf2_gnss_denied_limited;
@@ -2862,7 +2870,7 @@ int EKF2::task_spawn(int argc, char *argv[])
 		}
 
 		const hrt_abstime time_started = hrt_absolute_time();
-		const uint8_t num_pos_est_modes = (ekf2_gnss_denied == 1) ? 2 : 1;
+		const uint8_t num_pos_est_modes = (ekf2_gnss_denied != EKF2_GNSS_DENIED_DISABLED) ? 2 : 1;
 		const int multi_instances = math::min(imu_instances * mag_instances * num_pos_est_modes,
 						      static_cast<int32_t>(EKF2_MAX_INSTANCES));
 		int multi_instances_allocated = 0;
@@ -2885,7 +2893,9 @@ int EKF2::task_spawn(int argc, char *argv[])
 				uint8_t pos_est_mode = estimator_status_s::POS_EST_MODE_NORMAL;
 
 				if (mode == 1) {
-					pos_est_mode = estimator_status_s::POS_EST_MODE_GNSS_DENIED;
+					pos_est_mode = (ekf2_gnss_denied == EKF2_GNSS_DENIED_ALWAYS) ?
+						       estimator_status_s::POS_EST_MODE_GNSS_DENIED_ALWAYS :
+						       estimator_status_s::POS_EST_MODE_GNSS_DENIED_ARMED;
 				}
 
 				for (uint8_t mag = 0; mag < mag_instances; mag++) {

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -153,15 +153,19 @@ public:
 	static void unlock_module() { pthread_mutex_unlock(&ekf2_module_mutex); }
 
 #if defined(CONFIG_EKF2_MULTI_INSTANCE)
-	bool multi_init(int imu, int mag);
+	bool multi_init(int imu, int mag, uint8_t pos_est_mode = 0);
 #endif // CONFIG_EKF2_MULTI_INSTANCE
 
 	int instance() const { return _instance; }
+	uint8_t pos_est_mode() const { return _pos_est_mode; }
 
 private:
 
 	static constexpr uint8_t MAX_NUM_IMUS = 4;
 	static constexpr uint8_t MAX_NUM_MAGS = 4;
+
+	uint8_t _pos_est_mode{0}; ///< Position estimation mode (normal, vision-denied, or GNSS-denied)
+	bool _is_armed{false};    ///< Vehicle armed state (for GNSS-denied mode GPS skip)
 
 	void Run() override;
 

--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -858,7 +858,8 @@ void EKF2Selector::PrintStatus()
 
 		PX4_INFO("%" PRIu8 ": ACC: %" PRIu32 ", GYRO: %" PRIu32 ", MAG: %" PRIu32 ", %s%s, test ratio: %.7f (%.5f) %s",
 			 inst.instance, inst.accel_device_id, inst.gyro_device_id, inst.mag_device_id,
-			 inst.pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED ? "GNSS-denied, " : "",
+			 (inst.pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED_ARMED
+			  || inst.pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED_ALWAYS) ? "GNSS-denied, " : "",
 			 inst.healthy.get_state() ? "healthy" : "unhealthy",
 			 (double)inst.combined_test_ratio, (double)inst.relative_test_ratio,
 			 (_selected_instance == i) ? "*" : "");

--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -268,6 +268,7 @@ bool EKF2Selector::UpdateErrorScores()
 			_instance[i].gyro_device_id = status.gyro_device_id;
 			_instance[i].baro_device_id = status.baro_device_id;
 			_instance[i].mag_device_id = status.mag_device_id;
+			_instance[i].pos_est_mode = status.pos_est_mode;
 
 			if ((i + 1) > _available_instances) {
 				_available_instances = i + 1;
@@ -687,11 +688,12 @@ void EKF2Selector::Run()
 	// update combined test ratio for all estimators
 	const bool updated = UpdateErrorScores();
 
-	// if no valid instance then force select first instance with valid IMU
+	// if no valid instance then force select first instance with valid IMU (only normal mode, not GNSS-denied)
 	if (_selected_instance == INVALID_INSTANCE) {
 		for (uint8_t i = 0; i < EKF2_MAX_INSTANCES; i++) {
 			if ((_instance[i].accel_device_id != 0)
-			    && (_instance[i].gyro_device_id != 0)) {
+			    && (_instance[i].gyro_device_id != 0)
+			    && (_instance[i].pos_est_mode == estimator_status_s::POS_EST_MODE_NORMAL)) {
 
 				if (SelectInstance(i)) {
 					break;
@@ -721,7 +723,13 @@ void EKF2Selector::Run()
 		uint8_t best_ekf_different_imu = INVALID_INSTANCE;
 
 		// loop through all available instances to find if an alternative is available
+		// Only consider normal mode instances (not GNSS-denied)
 		for (int i = 0; i < _available_instances; i++) {
+			// Skip GNSS-denied instances - never select them
+			if (_instance[i].pos_est_mode != estimator_status_s::POS_EST_MODE_NORMAL) {
+				continue;
+			}
+
 			// Use an alternative instance if  -
 			// (healthy and has updated recently)
 			// AND
@@ -848,8 +856,9 @@ void EKF2Selector::PrintStatus()
 	for (int i = 0; i < _available_instances; i++) {
 		const EstimatorInstance &inst = _instance[i];
 
-		PX4_INFO("%" PRIu8 ": ACC: %" PRIu32 ", GYRO: %" PRIu32 ", MAG: %" PRIu32 ", %s, test ratio: %.7f (%.5f) %s",
+		PX4_INFO("%" PRIu8 ": ACC: %" PRIu32 ", GYRO: %" PRIu32 ", MAG: %" PRIu32 ", %s%s, test ratio: %.7f (%.5f) %s",
 			 inst.instance, inst.accel_device_id, inst.gyro_device_id, inst.mag_device_id,
+			 inst.pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED ? "GNSS-denied, " : "",
 			 inst.healthy.get_state() ? "healthy" : "unhealthy",
 			 (double)inst.combined_test_ratio, (double)inst.relative_test_ratio,
 			 (_selected_instance == i) ? "*" : "");

--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -126,6 +126,8 @@ private:
 		uint32_t baro_device_id{0};
 		uint32_t mag_device_id{0};
 
+		uint8_t pos_est_mode{0};
+
 		hrt_abstime time_last_selected{0};
 		hrt_abstime time_last_no_warning{0};
 

--- a/src/modules/ekf2/params_multi.yaml
+++ b/src/modules/ekf2/params_multi.yaml
@@ -28,11 +28,14 @@ parameters:
         long: When enabled, additional EKF2 instances are spawned that run without
           GPS aiding. This doubles the number of estimator instances (e.g. 3 IMUs
           becomes 6 instances - 3 normal + 3 GNSS-denied). Requires SENS_IMU_MODE 0.
+          'Only while armed' allows GPS fusion while disarmed for proper initialization.
+          'Always' disables GPS fusion at all times in the GNSS-denied instances.
       type: int32
       default: 0
       reboot_required: true
       min: 0
-      max: 1
+      max: 2
       values:
         0: Disabled
-        1: Enabled
+        1: Only while armed
+        2: Always

--- a/src/modules/ekf2/params_multi.yaml
+++ b/src/modules/ekf2/params_multi.yaml
@@ -22,3 +22,17 @@ parameters:
       reboot_required: true
       min: 0
       max: 4
+    EKF2_GNSS_DENIED:
+      description:
+        short: Enable GNSS-denied estimator instances
+        long: When enabled, additional EKF2 instances are spawned that run without
+          GPS aiding. This doubles the number of estimator instances (e.g. 3 IMUs
+          becomes 6 instances - 3 normal + 3 GNSS-denied). Requires SENS_IMU_MODE 0.
+      type: int32
+      default: 0
+      reboot_required: true
+      min: 0
+      max: 1
+      values:
+        0: Disabled
+        1: Enabled

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1450,6 +1450,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("AVIANT_HEARTBEAT", 1.0f);
 		configure_stream_local("AVIANT_DETAILED_FC_STATE", 1.0f);
 		configure_stream_local("AVIANT_NAV", 10.0f);
+		configure_stream_local("AVIANT_TRN_TEST_DATA", 10.0f);
 #endif // MAVLINK_ENABLED_AVIANT
 
 #if !defined(CONSTRAINED_FLASH)

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1532,6 +1532,10 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("VIBRATION", 0.5f);
 		configure_stream_local("WIND_COV", 10.0f);
 
+#if defined(MAVLINK_ENABLED_AVIANT)
+		configure_stream_local("AVIANT_TRN_TEST_DATA", 10.0f);
+#endif // MAVLINK_ENABLED_AVIANT
+
 #if !defined(CONSTRAINED_FLASH)
 		configure_stream_local("DEBUG", 10.0f);
 		configure_stream_local("DEBUG_FLOAT_ARRAY", 10.0f);

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -125,6 +125,7 @@
 #include "streams/AVIANT_HEARTBEAT.hpp"
 #include "streams/AVIANT_DETAILED_FC_STATE.hpp"
 #include "streams/AVIANT_NAV.hpp"
+#include "streams/AVIANT_TRN_TEST_DATA.hpp"
 #endif // MAVLINK_ENABLED_AVIANT
 
 #if defined(MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS)
@@ -521,6 +522,9 @@ static const StreamListItem streams_list[] = {
 #if defined (AVIANT_NAV_HPP)
 	create_stream_list_item<MavlinkStreamAviantNav>(),
 #endif // AVIANT_NAV_HPP
+#if defined (AVIANT_TRN_TEST_DATA_HPP)
+	create_stream_list_item<MavlinkStreamAviantTrnTestData>(),
+#endif // AVIANT_TRN_TEST_DATA_HPP
 };
 
 const char *get_stream_name(const uint16_t msg_id)

--- a/src/modules/mavlink/streams/AVIANT_TRN_TEST_DATA.hpp
+++ b/src/modules/mavlink/streams/AVIANT_TRN_TEST_DATA.hpp
@@ -36,6 +36,7 @@
 
 #include <uORB/topics/estimator_status.h>
 #include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_angular_velocity.h>
 #include <uORB/topics/vehicle_attitude.h>
 
 class MavlinkStreamAviantTrnTestData : public MavlinkStream
@@ -63,6 +64,7 @@ private:
 
 	uORB::Subscription _local_pos_sub{ORB_ID(estimator_local_position)};
 	uORB::Subscription _attitude_sub{ORB_ID(estimator_attitude)};
+	uORB::Subscription _angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};
 
 	void discoverGnssDeniedInstance()
 	{
@@ -99,9 +101,11 @@ private:
 
 		vehicle_local_position_s local_pos;
 		vehicle_attitude_s attitude;
+		vehicle_angular_velocity_s angular_velocity;
 
 		if (_local_pos_sub.update(&local_pos)) {
 			_attitude_sub.copy(&attitude);
+			_angular_velocity_sub.copy(&angular_velocity);
 
 			mavlink_aviant_trn_test_data_t msg{};
 
@@ -122,6 +126,11 @@ private:
 			msg.q2 = attitude.q[1];
 			msg.q3 = attitude.q[2];
 			msg.q4 = attitude.q[3];
+
+			// Angular velocity
+			msg.angular_velocity_x = angular_velocity.xyz[0];
+			msg.angular_velocity_y = angular_velocity.xyz[1];
+			msg.angular_velocity_z = angular_velocity.xyz[2];
 
 			mavlink_msg_aviant_trn_test_data_send_struct(_mavlink->get_channel(), &msg);
 

--- a/src/modules/mavlink/streams/AVIANT_TRN_TEST_DATA.hpp
+++ b/src/modules/mavlink/streams/AVIANT_TRN_TEST_DATA.hpp
@@ -36,8 +36,8 @@
 
 #include <uORB/topics/estimator_status.h>
 #include <uORB/topics/vehicle_local_position.h>
-#include <uORB/topics/vehicle_angular_velocity.h>
 #include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/vehicle_angular_velocity.h>
 
 class MavlinkStreamAviantTrnTestData : public MavlinkStream
 {
@@ -74,7 +74,8 @@ private:
 			estimator_status_s status;
 
 			if (status_sub.copy(&status)) {
-				if (status.pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED) {
+				if (status.pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED_ARMED
+				    || status.pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED_ALWAYS) {
 					_gnss_denied_instance = i;
 
 					// Subscribe to this instance's local position and attitude

--- a/src/modules/mavlink/streams/AVIANT_TRN_TEST_DATA.hpp
+++ b/src/modules/mavlink/streams/AVIANT_TRN_TEST_DATA.hpp
@@ -1,0 +1,144 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2024 Aviant. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef AVIANT_TRN_TEST_DATA_HPP
+#define AVIANT_TRN_TEST_DATA_HPP
+
+#include <uORB/topics/estimator_status.h>
+#include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_attitude.h>
+
+class MavlinkStreamAviantTrnTestData : public MavlinkStream
+{
+public:
+	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamAviantTrnTestData(mavlink); }
+
+	static constexpr const char *get_name_static() { return "AVIANT_TRN_TEST_DATA"; }
+	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_AVIANT_TRN_TEST_DATA; }
+
+	const char *get_name() const override { return get_name_static(); }
+	uint16_t get_id() override { return get_id_static(); }
+
+	unsigned get_size() override
+	{
+		return (_gnss_denied_instance >= 0) ? MAVLINK_MSG_ID_AVIANT_TRN_TEST_DATA_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES : 0;
+	}
+
+private:
+	static constexpr uint8_t MAX_INSTANCES = 9;
+
+	explicit MavlinkStreamAviantTrnTestData(Mavlink *mavlink) : MavlinkStream(mavlink) {}
+
+	int8_t _gnss_denied_instance{-1};
+	bool _discovery_attempted{false};
+
+	uORB::Subscription _local_pos_sub{ORB_ID(estimator_local_position)};
+	uORB::Subscription _attitude_sub{ORB_ID(estimator_attitude)};
+
+	void discoverGnssDeniedInstance()
+	{
+		if (_discovery_attempted) {
+			return;
+		}
+
+		_discovery_attempted = true;
+
+		// Search through estimator_status instances to find a GNSS-denied one
+		for (uint8_t i = 0; i < MAX_INSTANCES; i++) {
+			uORB::Subscription status_sub{ORB_ID(estimator_status), i};
+			estimator_status_s status;
+
+			if (status_sub.copy(&status)) {
+				if (status.pos_est_mode == estimator_status_s::POS_EST_MODE_GNSS_DENIED) {
+					_gnss_denied_instance = i;
+
+					// Subscribe to this instance's local position and attitude
+					_local_pos_sub = uORB::Subscription{ORB_ID(estimator_local_position), i};
+					_attitude_sub = uORB::Subscription{ORB_ID(estimator_attitude), i};
+
+					PX4_INFO("AVIANT_TRN_TEST_DATA: Found GNSS-denied EKF instance %d", i);
+					return;
+				}
+			}
+		}
+
+		PX4_WARN("AVIANT_TRN_TEST_DATA: No GNSS-denied EKF instance found");
+	}
+
+	bool send() override
+	{
+		// Try to discover the GNSS-denied instance on first call
+		if (_gnss_denied_instance < 0) {
+			discoverGnssDeniedInstance();
+
+			if (_gnss_denied_instance < 0) {
+				return false;
+			}
+		}
+
+		vehicle_local_position_s local_pos;
+		vehicle_attitude_s attitude;
+
+		if (_local_pos_sub.update(&local_pos)) {
+			_attitude_sub.copy(&attitude);
+
+			mavlink_aviant_trn_test_data_t msg{};
+
+			msg.time_boot_ms = local_pos.timestamp / 1000;
+
+			// Position
+			msg.x = local_pos.x;
+			msg.y = local_pos.y;
+			msg.z = local_pos.z;
+
+			// Velocity
+			msg.vx = local_pos.vx;
+			msg.vy = local_pos.vy;
+			msg.vz = local_pos.vz;
+
+			// Attitude quaternion
+			msg.q1 = attitude.q[0];
+			msg.q2 = attitude.q[1];
+			msg.q3 = attitude.q[2];
+			msg.q4 = attitude.q[3];
+
+			mavlink_msg_aviant_trn_test_data_send_struct(_mavlink->get_channel(), &msg);
+
+			return true;
+		}
+
+		return false;
+	}
+};
+
+#endif // AVIANT_TRN_TEST_DATA_HPP

--- a/src/modules/mavlink/streams/AVIANT_TRN_TEST_DATA.hpp
+++ b/src/modules/mavlink/streams/AVIANT_TRN_TEST_DATA.hpp
@@ -60,19 +60,12 @@ private:
 	explicit MavlinkStreamAviantTrnTestData(Mavlink *mavlink) : MavlinkStream(mavlink) {}
 
 	int8_t _gnss_denied_instance{-1};
-	bool _discovery_attempted{false};
 
 	uORB::Subscription _local_pos_sub{ORB_ID(estimator_local_position)};
 	uORB::Subscription _attitude_sub{ORB_ID(estimator_attitude)};
 
 	void discoverGnssDeniedInstance()
 	{
-		if (_discovery_attempted) {
-			return;
-		}
-
-		_discovery_attempted = true;
-
 		// Search through estimator_status instances to find a GNSS-denied one
 		for (uint8_t i = 0; i < MAX_INSTANCES; i++) {
 			uORB::Subscription status_sub{ORB_ID(estimator_status), i};
@@ -91,13 +84,11 @@ private:
 				}
 			}
 		}
-
-		PX4_WARN("AVIANT_TRN_TEST_DATA: No GNSS-denied EKF instance found");
 	}
 
 	bool send() override
 	{
-		// Try to discover the GNSS-denied instance on first call
+		// Retry discovery until the GNSS-denied instance is found
 		if (_gnss_denied_instance < 0) {
 			discoverGnssDeniedInstance();
 

--- a/test/gnss_denied_tests/conftest.py
+++ b/test/gnss_denied_tests/conftest.py
@@ -1,0 +1,240 @@
+"""pytest fixtures for GNSS-denied SITL tests.
+
+Each test gets a fresh PX4 SITL instance with GNSS-denied EKF instances
+enabled (PX4_EKF2_GNSS_DENIED=1).  The SIH simulator provides sensor
+data without needing Gazebo.
+
+Parameters are passed as environment variables to the PX4 process.
+The rcS startup script reads PX4_EKF2_GNSS_DENIED and applies
+``param set SENS_IMU_MODE 0`` and ``param set EKF2_GNSS_DENIED 1``.
+"""
+
+from __future__ import annotations
+
+import os
+
+WORKSPACE = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+DEFAULT_BUILD_DIR = os.path.join(WORKSPACE, 'build', 'px4_sitl_default')
+
+# Build the aviant dialect from the in-tree mavlink XML definitions.
+# These must be set before pymavlink is imported.
+os.environ['MAVLINK20'] = '1'
+os.environ['MAVLINK_DIALECT'] = 'aviant'
+os.environ['MDEF'] = os.path.join(
+    WORKSPACE, 'src', 'modules', 'mavlink', 'mavlink', 'message_definitions')
+
+import logging
+import shutil
+import signal
+import subprocess
+import threading
+import time
+
+import psutil
+import pytest
+from pymavlink import mavutil
+
+from gnss_denied_tester import GnssDeniedTester
+
+log = logging.getLogger(__name__)
+
+MAV_PORT = 14540
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--build-dir', action='store', default=DEFAULT_BUILD_DIR,
+        help='Path to the PX4 SITL build directory',
+    )
+
+
+# ------------------------------------------------------------------
+# PX4 lifecycle helpers
+# ------------------------------------------------------------------
+
+def _kill_existing_px4():
+    for proc in psutil.process_iter(['name']):
+        if proc.info['name'] == 'px4':
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+class PX4Instance:
+    """Wraps a running PX4 SITL process with stdout-based boot detection."""
+
+    def __init__(self, proc: subprocess.Popen):
+        self.proc = proc
+        self._lines: list[str] = []
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+
+    def _read_loop(self):
+        assert self.proc.stdout is not None
+        while not self._stop.is_set():
+            line = self.proc.stdout.readline()
+            if not line:
+                if self.proc.poll() is not None:
+                    break
+                time.sleep(0.01)
+                continue
+            with self._lock:
+                self._lines.append(line)
+
+    def wait_for_line(self, needle: str, timeout_s: float = 30.0) -> bool:
+        """Wait until a line containing *needle* (case-insensitive) appears."""
+        deadline = time.monotonic() + timeout_s
+        seen = 0
+        while time.monotonic() < deadline:
+            with self._lock:
+                while seen < len(self._lines):
+                    if needle.lower() in self._lines[seen].lower():
+                        return True
+                    seen += 1
+            time.sleep(0.05)
+        return False
+
+    def stop(self):
+        self._stop.set()
+        if self.proc.poll() is None:
+            self.proc.send_signal(signal.SIGTERM)
+            try:
+                self.proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait(timeout=3)
+        self._reader.join(timeout=3)
+
+
+def _start_px4(build_dir: str,
+               extra_env: dict[str, str] | None = None) -> PX4Instance:
+    rootfs = os.path.join(build_dir, 'tmp_gnss_denied_tests', 'rootfs')
+
+    if os.path.isdir(rootfs):
+        for item in os.listdir(rootfs):
+            if item == 'log':
+                continue
+            path = os.path.join(rootfs, item)
+            if os.path.isfile(path) or os.path.islink(path):
+                os.remove(path)
+            else:
+                shutil.rmtree(path)
+    os.makedirs(rootfs, exist_ok=True)
+
+    env = os.environ.copy()
+    env['PX4_SIM_MODEL'] = 'sihsim_quadx'
+    env['PX4_SIM_SPEED_FACTOR'] = '10'
+    env['PX4_EKF2_GNSS_DENIED'] = '1'
+    env['SYS_FAILURE_EN'] = '1'
+
+    if extra_env:
+        env.update(extra_env)
+
+    px4_bin = os.path.join(build_dir, 'bin', 'px4')
+    etc_dir = os.path.join(build_dir, 'etc')
+
+    proc = subprocess.Popen(
+        [
+            px4_bin,
+            etc_dir,
+            '-s', 'etc/init.d-posix/rcS',
+            '-d',
+        ],
+        cwd=rootfs,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+    )
+
+    instance = PX4Instance(proc)
+
+    if not instance.wait_for_line('startup script returned', timeout_s=30):
+        instance.stop()
+        raise TimeoutError('PX4 did not complete boot within timeout')
+
+    return instance
+
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+@pytest.fixture()
+def px4(request):
+    """Start a fresh PX4 SITL for each test with GNSS-denied mode enabled.
+
+    Tests can provide extra env vars via ``pytest.mark.parametrize``
+    on the indirect ``px4`` fixture.
+    """
+    build_dir = os.path.abspath(request.config.getoption('--build-dir'))
+
+    if not os.path.isfile(os.path.join(build_dir, 'bin', 'px4')):
+        pytest.skip(
+            f'PX4 binary not found at {build_dir}/bin/px4 -- '
+            'run `DONT_RUN=1 make px4_sitl` first')
+
+    params = getattr(request, 'param', None)
+
+    t0 = time.monotonic()
+    log.info("Killing existing PX4 instances...")
+    _kill_existing_px4()
+    log.info("Starting PX4 SITL (build_dir=%s, params=%s)...", build_dir, params)
+    t1 = time.monotonic()
+    instance = _start_px4(build_dir, extra_env=params)
+    log.info("PX4 booted in %.2fs", time.monotonic() - t1)
+
+    yield instance
+
+    log.info("Stopping PX4 (fixture was alive for %.2fs)...", time.monotonic() - t0)
+    instance.stop()
+    _kill_existing_px4()
+
+
+@pytest.fixture()
+def tester(px4):
+    """Provide a GnssDeniedTester connected to the running PX4 instance.
+
+    Blocks until EKF2 achieves tilt alignment (publishes ATTITUDE)
+    so that offboard control and GNSS-denied instances are ready.
+    """
+    t0 = time.monotonic()
+    time.sleep(1)
+
+    log.info("Connecting pymavlink to udpin:0.0.0.0:%d...", MAV_PORT)
+    conn = mavutil.mavlink_connection(
+        f'udpin:0.0.0.0:{MAV_PORT}',
+        source_system=255,
+        source_component=0,
+    )
+
+    log.info("Waiting for HEARTBEAT...")
+    t1 = time.monotonic()
+    conn.wait_heartbeat(timeout=15)
+    log.info("HEARTBEAT received after %.2fs", time.monotonic() - t1)
+
+    # Wait for EKF2 tilt alignment.
+    log.info("Waiting for EKF2 tilt alignment (ATTITUDE message)...")
+    t1 = time.monotonic()
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        msg = conn.recv_match(type='ATTITUDE', blocking=True, timeout=1.0)
+        if msg is not None:
+            break
+    else:
+        raise TimeoutError('EKF2 did not achieve tilt alignment within 60 s')
+    log.info("EKF2 tilt aligned after %.2fs", time.monotonic() - t1)
+
+    t = GnssDeniedTester(conn)
+
+    # Let GNSS-denied instances initialize (1s wall = 10s sim at speed factor 10).
+    log.info("Waiting 1s for GNSS-denied instances to initialize...")
+    time.sleep(1.0)
+
+    log.info("Tester ready (fixture setup took %.2fs)", time.monotonic() - t0)
+
+    yield t
+
+    t.shutdown()
+    conn.close()

--- a/test/gnss_denied_tests/gnss_denied_tester.py
+++ b/test/gnss_denied_tests/gnss_denied_tester.py
@@ -1,0 +1,176 @@
+"""Helper class for GNSS-denied SITL tests using pymavlink.
+
+Thin wrapper around a pymavlink connection for receiving
+AVIANT_TRN_TEST_DATA, sending external position estimates,
+and injecting GPS failures.
+
+Requires the ``aviant`` MAVLink dialect (set MAVLINK_DIALECT=aviant and
+MDEF pointing at the in-tree message_definitions before importing
+pymavlink).  See conftest.py.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+
+from pymavlink import mavutil
+
+mavlink = mavutil.mavlink
+
+MAV_CMD_EXTERNAL_POSITION_ESTIMATE = 43003
+
+
+class GnssDeniedTester:
+    """Drives GNSS-denied test scenarios over MAVLink."""
+
+    def __init__(self, connection: mavutil.mavlink_connection):
+        self.conn = connection
+        self._target_sys = 1
+        self._target_comp = 1
+
+    # ------------------------------------------------------------------
+    # TRN test data (AVIANT_TRN_TEST_DATA)
+    # ------------------------------------------------------------------
+
+    def get_trn_test_data(self, timeout_s: float = 5.0):
+        """Receive a fresh AVIANT_TRN_TEST_DATA message."""
+        while self.conn.recv_match(
+                type='AVIANT_TRN_TEST_DATA', blocking=False) is not None:
+            pass
+        return self.conn.recv_match(
+            type='AVIANT_TRN_TEST_DATA', blocking=True, timeout=timeout_s)
+
+    def get_gnss_denied_position(self, timeout_s: float = 5.0):
+        """Return (x, y, z) from AVIANT_TRN_TEST_DATA."""
+        msg = self.get_trn_test_data(timeout_s=timeout_s)
+        if msg is None:
+            return (math.nan, math.nan, math.nan)
+        return (msg.x, msg.y, msg.z)
+
+    def collect_trn_data(self, duration_s: float = 5.0) -> list:
+        """Collect AVIANT_TRN_TEST_DATA messages for a fixed duration."""
+        # Drain stale messages.
+        while self.conn.recv_match(
+                type='AVIANT_TRN_TEST_DATA', blocking=False) is not None:
+            pass
+
+        messages = []
+        deadline = time.monotonic() + duration_s
+        while time.monotonic() < deadline:
+            msg = self.conn.recv_match(
+                type='AVIANT_TRN_TEST_DATA', blocking=True, timeout=0.5)
+            if msg is not None:
+                messages.append(msg)
+        return messages
+
+    # ------------------------------------------------------------------
+    # Local position (normal EKF instance)
+    # ------------------------------------------------------------------
+
+    def get_local_position(self, timeout_s: float = 3.0):
+        """Return (x, y, z) from LOCAL_POSITION_NED."""
+        msg = self.conn.recv_match(
+            type='LOCAL_POSITION_NED', blocking=True, timeout=timeout_s)
+        if msg is None:
+            return (math.nan, math.nan, math.nan)
+        return (msg.x, msg.y, msg.z)
+
+    # ------------------------------------------------------------------
+    # External position estimate
+    # ------------------------------------------------------------------
+
+    def send_external_position_estimate(self, lat: float, lon: float,
+                                        accuracy: float = 10.0):
+        """Send MAV_CMD_EXTERNAL_POSITION_ESTIMATE."""
+        att = self.conn.recv_match(type='ATTITUDE', blocking=True, timeout=3.0)
+        if att is None:
+            raise TimeoutError('No ATTITUDE message for timestamp')
+
+        self.conn.mav.command_long_send(
+            self._target_sys, self._target_comp,
+            MAV_CMD_EXTERNAL_POSITION_ESTIMATE, 0,
+            att.time_boot_ms / 1000.0,  # param1: FC timestamp
+            0.0,                        # param2: processing_time
+            accuracy,                   # param3: accuracy
+            0.0,                        # param4: empty
+            lat,                        # param5: latitude
+            lon,                        # param6: longitude
+            float('nan'),               # param7: altitude (unused)
+        )
+
+    # ------------------------------------------------------------------
+    # Home position
+    # ------------------------------------------------------------------
+
+    def get_home(self, timeout_s: float = 10.0):
+        """Return (lat_deg, lon_deg) from HOME_POSITION."""
+        msg = self.conn.recv_match(
+            type='HOME_POSITION', blocking=True, timeout=timeout_s)
+        if msg is None:
+            raise TimeoutError('Did not receive HOME_POSITION')
+        return (msg.latitude / 1e7, msg.longitude / 1e7)
+
+    # ------------------------------------------------------------------
+    # GPS failure injection
+    # ------------------------------------------------------------------
+
+    def inject_gps_failure(self):
+        """Disable GPS via MAV_CMD_INJECT_FAILURE."""
+        self.conn.mav.command_long_send(
+            self._target_sys, self._target_comp,
+            mavlink.MAV_CMD_INJECT_FAILURE, 0,
+            4.0,  # FAILURE_UNIT_SENSOR_GPS
+            1.0,  # FAILURE_TYPE_OFF
+            0.0,  # instance (0 = all)
+            0, 0, 0, 0,
+        )
+
+    # ------------------------------------------------------------------
+    # Arming / takeoff / disarm detection
+    # ------------------------------------------------------------------
+
+    def takeoff(self, alt: float = 10.0):
+        """Arm and takeoff to altitude via MAV_CMD_NAV_TAKEOFF."""
+        self.conn.mav.command_long_send(
+            self._target_sys, self._target_comp,
+            mavlink.MAV_CMD_COMPONENT_ARM_DISARM, 0,
+            1.0, 0, 0, 0, 0, 0, 0,
+        )
+        self._wait_ack(mavlink.MAV_CMD_COMPONENT_ARM_DISARM)
+
+        self.conn.mav.command_long_send(
+            self._target_sys, self._target_comp,
+            mavlink.MAV_CMD_NAV_TAKEOFF, 0,
+            0, 0, 0, 0, 0, 0, alt,
+        )
+        self._wait_ack(mavlink.MAV_CMD_NAV_TAKEOFF)
+
+    def wait_until_disarmed(self, timeout_s: float = 60.0):
+        """Block until the vehicle disarms."""
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            msg = self.conn.recv_match(type='HEARTBEAT', blocking=True, timeout=1.0)
+            if msg and not (msg.base_mode & mavlink.MAV_MODE_FLAG_SAFETY_ARMED):
+                return
+        raise TimeoutError(f'Vehicle did not disarm within {timeout_s}s')
+
+    def set_param_int(self, param_id: str, value: int):
+        """Set a PX4 integer parameter."""
+        self.conn.mav.param_set_send(
+            self._target_sys, self._target_comp,
+            param_id.encode('utf-8'),
+            float(value),
+            mavlink.MAV_PARAM_TYPE_INT32,
+        )
+
+    def _wait_ack(self, command: int, timeout_s: float = 5.0):
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            msg = self.conn.recv_match(type='COMMAND_ACK', blocking=True, timeout=0.5)
+            if msg and msg.command == command:
+                return msg
+        return None
+
+    def shutdown(self):
+        pass

--- a/test/gnss_denied_tests/gnss_denied_tester.py
+++ b/test/gnss_denied_tests/gnss_denied_tester.py
@@ -76,27 +76,37 @@ class GnssDeniedTester:
             return (math.nan, math.nan, math.nan)
         return (msg.x, msg.y, msg.z)
 
+    def get_global_position(self, timeout_s: float = 3.0):
+        """Return (lat_deg, lon_deg) from GLOBAL_POSITION_INT."""
+        msg = self.conn.recv_match(
+            type='GLOBAL_POSITION_INT', blocking=True, timeout=timeout_s)
+        if msg is None:
+            return (math.nan, math.nan)
+        return (msg.lat / 1e7, msg.lon / 1e7)
+
     # ------------------------------------------------------------------
     # External position estimate
     # ------------------------------------------------------------------
 
     def send_external_position_estimate(self, lat: float, lon: float,
                                         accuracy: float = 10.0):
-        """Send MAV_CMD_EXTERNAL_POSITION_ESTIMATE."""
+        """Send MAV_CMD_EXTERNAL_POSITION_ESTIMATE via COMMAND_INT for lat/lon precision."""
         att = self.conn.recv_match(type='ATTITUDE', blocking=True, timeout=3.0)
         if att is None:
             raise TimeoutError('No ATTITUDE message for timestamp')
 
-        self.conn.mav.command_long_send(
+        self.conn.mav.command_int_send(
             self._target_sys, self._target_comp,
-            MAV_CMD_EXTERNAL_POSITION_ESTIMATE, 0,
-            att.time_boot_ms / 1000.0,  # param1: FC timestamp
-            0.0,                        # param2: processing_time
-            accuracy,                   # param3: accuracy
-            0.0,                        # param4: empty
-            lat,                        # param5: latitude
-            lon,                        # param6: longitude
-            float('nan'),               # param7: altitude (unused)
+            0,                                  # frame (unused)
+            MAV_CMD_EXTERNAL_POSITION_ESTIMATE,
+            0, 0,                               # current, autocontinue
+            att.time_boot_ms / 1000.0,          # param1: FC timestamp
+            0.0,                                # param2: processing_time
+            accuracy,                           # param3: accuracy
+            0.0,                                # param4: empty
+            int(lat * 1e7),                     # x: latitude (degE7)
+            int(lon * 1e7),                     # y: longitude (degE7)
+            float('nan'),                       # z: altitude (unused)
         )
 
     # ------------------------------------------------------------------
@@ -163,6 +173,15 @@ class GnssDeniedTester:
             float(value),
             mavlink.MAV_PARAM_TYPE_INT32,
         )
+
+    def land(self):
+        """Command the vehicle to land at the current position."""
+        self.conn.mav.command_long_send(
+            self._target_sys, self._target_comp,
+            mavlink.MAV_CMD_NAV_LAND, 0,
+            0, 0, 0, 0, 0, 0, 0,
+        )
+        self._wait_ack(mavlink.MAV_CMD_NAV_LAND)
 
     def _wait_ack(self, command: int, timeout_s: float = 5.0):
         deadline = time.monotonic() + timeout_s

--- a/test/gnss_denied_tests/requirements.txt
+++ b/test/gnss_denied_tests/requirements.txt
@@ -1,0 +1,3 @@
+pymavlink
+pytest
+psutil

--- a/test/gnss_denied_tests/test_gnss_denied.py
+++ b/test/gnss_denied_tests/test_gnss_denied.py
@@ -1,0 +1,165 @@
+"""SITL integration tests for GNSS-denied EKF instances.
+
+Each test starts a fresh PX4 SITL with GNSS-denied mode enabled
+(PX4_EKF2_GNSS_DENIED=1).  SIH provides simulated sensors.
+
+Tests 1, 2, 4 need only a booted PX4 with EKF2 running (no flight).
+Test 3 needs armed flight to verify GPS-loss failsafe behavior.
+"""
+
+import logging
+import math
+import time
+
+import pytest
+from gnss_denied_tester import GnssDeniedTester
+
+log = logging.getLogger(__name__)
+
+
+def _ts():
+    """Monotonic timestamp for relative timing."""
+    return time.monotonic()
+
+
+def _elapsed(start: float) -> str:
+    return f"{time.monotonic() - start:.2f}s"
+
+
+def test_gnss_denied_instance_exists(tester: GnssDeniedTester):
+    """GNSS-denied EKF instance runs and produces finite position data."""
+    t0 = _ts()
+    log.info("Waiting for AVIANT_TRN_TEST_DATA...")
+    trn = tester.get_trn_test_data(timeout_s=5.0)
+    log.info("TRN data received after %s: %s",
+             _elapsed(t0), trn is not None)
+    assert trn is not None, \
+        "No AVIANT_TRN_TEST_DATA -- GNSS-denied instance not running"
+
+    log.info("TRN pos: x=%.2f y=%.2f z=%.2f", trn.x, trn.y, trn.z)
+    assert math.isfinite(trn.x)
+    assert math.isfinite(trn.y)
+    assert math.isfinite(trn.z)
+
+    log.info("Waiting for LOCAL_POSITION_NED...")
+    t1 = _ts()
+    pos = tester.get_local_position()
+    log.info("Normal pos after %s: x=%.2f y=%.2f z=%.2f",
+             _elapsed(t1), *pos)
+    assert math.isfinite(pos[0])
+    assert math.isfinite(pos[1])
+    assert math.isfinite(pos[2])
+
+    log.info("Test complete in %s", _elapsed(t0))
+
+
+def test_external_position_resets_only_gnss_denied(tester: GnssDeniedTester):
+    """External position estimate resets GNSS-denied instance, not normal."""
+    t0 = _ts()
+
+    log.info("Getting GNSS-denied position before reset...")
+    t1 = _ts()
+    pos_before = tester.get_gnss_denied_position()
+    log.info("GNSS-denied pos (before) after %s: x=%.2f y=%.2f z=%.2f",
+             _elapsed(t1), *pos_before)
+    assert math.isfinite(pos_before[0]), "Pre-reset position not finite"
+
+    log.info("Getting normal position before reset...")
+    t1 = _ts()
+    normal_before = tester.get_local_position()
+    log.info("Normal pos (before) after %s: x=%.2f y=%.2f z=%.2f",
+             _elapsed(t1), *normal_before)
+
+    log.info("Getting home position...")
+    t1 = _ts()
+    home_lat, home_lon = tester.get_home()
+    log.info("Home after %s: lat=%.6f lon=%.6f", _elapsed(t1), home_lat, home_lon)
+
+    log.info("Sending EXTERNAL_POSITION_ESTIMATE (~50m north)...")
+    tester.send_external_position_estimate(home_lat + 0.00045, home_lon)
+
+    log.info("Waiting 2s for reset to take effect...")
+    time.sleep(2)
+
+    log.info("Getting GNSS-denied position after reset...")
+    t1 = _ts()
+    pos_after = tester.get_gnss_denied_position()
+    log.info("GNSS-denied pos (after) after %s: x=%.2f y=%.2f z=%.2f",
+             _elapsed(t1), *pos_after)
+
+    dx = pos_after[0] - pos_before[0]
+    dy = pos_after[1] - pos_before[1]
+    change = math.sqrt(dx * dx + dy * dy)
+    log.info("GNSS-denied horizontal change: %.1fm", change)
+    assert change > 10.0, \
+        f"GNSS-denied position should jump >10m, got {change:.1f}m"
+
+    log.info("Getting normal position after reset...")
+    t1 = _ts()
+    normal_after = tester.get_local_position()
+    log.info("Normal pos (after) after %s: x=%.2f y=%.2f z=%.2f",
+             _elapsed(t1), *normal_after)
+
+    drift = math.sqrt(
+        (normal_after[0] - normal_before[0]) ** 2
+        + (normal_after[1] - normal_before[1]) ** 2)
+    log.info("Normal instance drift: %.2fm", drift)
+    assert drift < 2.0, \
+        f"Normal instance drifted {drift:.1f}m -- should be stationary"
+
+    log.info("Test complete in %s", _elapsed(t0))
+
+
+def test_selector_ignores_gnss_denied_on_gps_loss(tester: GnssDeniedTester):
+    """On GPS loss the selector uses a normal instance (vehicle failsafes)."""
+    t0 = _ts()
+
+    log.info("Setting SYS_FAILURE_EN=1...")
+    tester.set_param_int('SYS_FAILURE_EN', 1)
+
+    log.info("Commanding takeoff to 10m...")
+    t1 = _ts()
+    tester.takeoff(alt=10.0)
+    log.info("Takeoff command sent after %s", _elapsed(t1))
+
+    log.info("Waiting 5s for climb...")
+    time.sleep(5)
+
+    log.info("Injecting GPS failure...")
+    t1 = _ts()
+    tester.inject_gps_failure()
+    log.info("GPS failure injected at %s", _elapsed(t0))
+
+    log.info("Waiting for disarm (failsafe land)...")
+    t1 = _ts()
+    tester.wait_until_disarmed(timeout_s=300)
+    log.info("Disarmed after %s (total: %s)", _elapsed(t1), _elapsed(t0))
+
+
+def test_trn_data_stream_valid(tester: GnssDeniedTester):
+    """AVIANT_TRN_TEST_DATA stream has valid fields and unit quaternion."""
+    t0 = _ts()
+
+    log.info("Collecting TRN data for 5s...")
+    messages = tester.collect_trn_data(duration_s=5.0)
+    log.info("Collected %d messages in %s", len(messages), _elapsed(t0))
+    assert len(messages) >= 5, \
+        f"Expected >= 5 TRN messages in 5s, got {len(messages)}"
+
+    data = messages[-1]
+    log.info("Last message: time_boot_ms=%d pos=(%.2f, %.2f, %.2f) "
+             "vel=(%.2f, %.2f, %.2f) quat=(%.3f, %.3f, %.3f, %.3f)",
+             data.time_boot_ms, data.x, data.y, data.z,
+             data.vx, data.vy, data.vz,
+             data.q1, data.q2, data.q3, data.q4)
+
+    assert data.time_boot_ms > 0
+    for field in ('x', 'y', 'z', 'vx', 'vy', 'vz', 'q1', 'q2', 'q3', 'q4'):
+        assert math.isfinite(getattr(data, field)), f"{field} is not finite"
+
+    quat_norm = math.sqrt(data.q1**2 + data.q2**2 + data.q3**2 + data.q4**2)
+    log.info("Quaternion norm: %.4f", quat_norm)
+    assert abs(quat_norm - 1.0) < 0.01, \
+        f"Quaternion norm should be ~1.0, got {quat_norm:.4f}"
+
+    log.info("Test complete in %s", _elapsed(t0))

--- a/test/gnss_denied_tests/test_gnss_denied.py
+++ b/test/gnss_denied_tests/test_gnss_denied.py
@@ -3,8 +3,8 @@
 Each test starts a fresh PX4 SITL with GNSS-denied mode enabled
 (PX4_EKF2_GNSS_DENIED=1).  SIH provides simulated sensors.
 
-Tests 1, 2, 4 need only a booted PX4 with EKF2 running (no flight).
-Test 3 needs armed flight to verify GPS-loss failsafe behavior.
+Tests 1, 4 need only a booted PX4 with EKF2 running (no flight).
+Tests 2, 3 need armed flight.
 """
 
 import logging
@@ -54,58 +54,75 @@ def test_gnss_denied_instance_exists(tester: GnssDeniedTester):
 
 
 def test_external_position_resets_only_gnss_denied(tester: GnssDeniedTester):
-    """External position estimate resets GNSS-denied instance, not normal."""
+    """External position estimate resets GNSS-denied instance, not normal.
+
+    1. Takeoff and hold — the GNSS-denied instance stops fusing GPS on
+       arming and enters dead reckoning within ~1 s sim time.
+    2. Send an external position reset to current position + 100 m east.
+    3. Assert LOCAL_POSITION does not jump (< 1 m) and TRN position jumps
+       significantly (> 80 m).
+
+    Note: SIH provides near-perfect IMU data so the GNSS-denied instance
+    drifts back toward reality after a reset.  A 100 m offset ensures the
+    jump is still clearly visible when TRN is read ~1 s sim-time later.
+    """
     t0 = _ts()
 
-    log.info("Getting GNSS-denied position before reset...")
-    t1 = _ts()
-    pos_before = tester.get_gnss_denied_position()
-    log.info("GNSS-denied pos (before) after %s: x=%.2f y=%.2f z=%.2f",
-             _elapsed(t1), *pos_before)
-    assert math.isfinite(pos_before[0]), "Pre-reset position not finite"
+    # Drain any pending ACKs so they don't interfere with arm ACK
+    while tester.conn.recv_match(type='COMMAND_ACK', blocking=False) is not None:
+        pass
 
-    log.info("Getting normal position before reset...")
-    t1 = _ts()
-    normal_before = tester.get_local_position()
-    log.info("Normal pos (before) after %s: x=%.2f y=%.2f z=%.2f",
-             _elapsed(t1), *normal_before)
+    # -- 1. Takeoff and hold ------------------------------------------------
+    log.info("Commanding takeoff to 10m...")
+    tester.takeoff(alt=10.0)
 
-    log.info("Getting home position...")
-    t1 = _ts()
-    home_lat, home_lon = tester.get_home()
-    log.info("Home after %s: lat=%.6f lon=%.6f", _elapsed(t1), home_lat, home_lon)
+    # At 10× speed the vehicle reaches altitude quickly — wait 1 s wall
+    # (= 10 s sim) to stay well within the armed window.
+    log.info("Waiting 1s for climb...")
+    time.sleep(1)
 
-    log.info("Sending EXTERNAL_POSITION_ESTIMATE (~50m north)...")
-    tester.send_external_position_estimate(home_lat + 0.00045, home_lon)
+    # Verify the vehicle is actually armed
+    hb = tester.conn.recv_match(type='HEARTBEAT', blocking=True, timeout=3.0)
+    assert hb and (hb.base_mode & 128), \
+        "Vehicle not armed — cannot test external position reset"
 
-    log.info("Waiting 2s for reset to take effect...")
-    time.sleep(2)
+    # -- 2. External position reset -----------------------------------------
+    #    Reset target = current position + 100 m east (in lat/lon).
+    trn_before = tester.get_gnss_denied_position()
+    log.info("TRN before reset: x=%.2f y=%.2f z=%.2f", *trn_before)
+    assert math.isfinite(trn_before[0]), "TRN position not finite"
 
-    log.info("Getting GNSS-denied position after reset...")
-    t1 = _ts()
-    pos_after = tester.get_gnss_denied_position()
-    log.info("GNSS-denied pos (after) after %s: x=%.2f y=%.2f z=%.2f",
-             _elapsed(t1), *pos_after)
+    local_before = tester.get_local_position()
+    log.info("LOCAL before reset: x=%.2f y=%.2f z=%.2f", *local_before)
 
-    dx = pos_after[0] - pos_before[0]
-    dy = pos_after[1] - pos_before[1]
-    change = math.sqrt(dx * dx + dy * dy)
-    log.info("GNSS-denied horizontal change: %.1fm", change)
-    assert change > 10.0, \
-        f"GNSS-denied position should jump >10m, got {change:.1f}m"
+    cur_lat, cur_lon = tester.get_global_position()
+    # 111320 m/deg is Earth's circumference / 360; cos(lat) corrects for longitude convergence
+    lon_offset = 100.0 / (111320.0 * math.cos(math.radians(cur_lat)))
+    tester.send_external_position_estimate(cur_lat, cur_lon + lon_offset)
 
-    log.info("Getting normal position after reset...")
-    t1 = _ts()
-    normal_after = tester.get_local_position()
-    log.info("Normal pos (after) after %s: x=%.2f y=%.2f z=%.2f",
-             _elapsed(t1), *normal_after)
+    log.info("Waiting 0.1s for reset to take effect...")
+    time.sleep(0.1)
 
-    drift = math.sqrt(
-        (normal_after[0] - normal_before[0]) ** 2
-        + (normal_after[1] - normal_before[1]) ** 2)
-    log.info("Normal instance drift: %.2fm", drift)
-    assert drift < 2.0, \
-        f"Normal instance drifted {drift:.1f}m -- should be stationary"
+    # -- 3. Assertions ------------------------------------------------------
+    # LOCAL_POSITION should not jump.
+    local_after = tester.get_local_position()
+    local_jump = math.sqrt(
+        (local_after[0] - local_before[0]) ** 2
+        + (local_after[1] - local_before[1]) ** 2)
+    log.info("LOCAL after reset: x=%.2f y=%.2f z=%.2f  jump=%.2fm",
+             *local_after, local_jump)
+    assert local_jump < 1.0, \
+        f"LOCAL_POSITION jumped {local_jump:.2f}m -- reset leaked into normal instance"
+
+    # TRN position should jump toward the reset target.
+    trn_after = tester.get_gnss_denied_position()
+    trn_jump = math.sqrt(
+        (trn_after[0] - trn_before[0]) ** 2
+        + (trn_after[1] - trn_before[1]) ** 2)
+    log.info("TRN after reset: x=%.2f y=%.2f z=%.2f  jump=%.2fm",
+             *trn_after, trn_jump)
+    assert trn_jump > 80.0, \
+        f"TRN position should jump significantly, got {trn_jump:.2f}m -- reset not accepted"
 
     log.info("Test complete in %s", _elapsed(t0))
 


### PR DESCRIPTION
DO NOT MERGE

For open-loop testing of GNSS-denied navigation aids

TODOs before first flight test:

- [x] Publish GNSS-denied estimate in separate MAVLink stream
- [ ] Ground test

TODOs before merge:

- [x] Merge MAVLink message definition in mavlink repo, since we want our submodule pointing to `aviant/main`, and update pointer here
- [x] Populate angular velocity fields
