### PR TITLE
Filter lookahead angles

### DIFF
--- a/msg/VtolVehicleStatus.msg
+++ b/msg/VtolVehicleStatus.msg
@@ -12,7 +12,6 @@ uint8 vehicle_vtol_state		# current state of the vtol, see VEHICLE_VTOL_STATE
 bool fixed_wing_system_failure		# vehicle in fixed-wing system failure failsafe mode (after quad-chute)
 
 float32 airspeed_filtered		# Filtered airspeed used during transition. NAN if invalid
-float32[4] mc_weights			# Multicopter blending weights for [roll, pitch, yaw, throttle]
 
 float32 lookahead_roll			# Predicted roll angle for quadchute lookahead [rad]
 float32 lookahead_pitch			# Predicted pitch angle for quadchute lookahead [rad]

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -463,10 +463,6 @@ VtolAttitudeControl::Run()
 
 		// Advertise/Publish vtol vehicle status
 		_vtol_vehicle_status.airspeed_filtered = get_filtered_airspeed();
-		_vtol_vehicle_status.mc_weights[0] = _vtol_type->get_mc_roll_weight();
-		_vtol_vehicle_status.mc_weights[1] = _vtol_type->get_mc_pitch_weight();
-		_vtol_vehicle_status.mc_weights[2] = _vtol_type->get_mc_yaw_weight();
-		_vtol_vehicle_status.mc_weights[3] = _vtol_type->get_mc_throttle_weight();
 		_vtol_vehicle_status.lookahead_pitch = _qc_lookahead_pitch.getState();
 		_vtol_vehicle_status.lookahead_roll = _qc_lookahead_roll.getState();
 		_vtol_vehicle_status.timestamp = hrt_absolute_time();

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -459,14 +459,16 @@ VtolAttitudeControl::Run()
 		_vehicle_thrust_setpoint0_pub.publish(_thrust_setpoint_0);
 		_vehicle_thrust_setpoint1_pub.publish(_thrust_setpoint_1);
 
+		update_qc_lookahead_angles();
+
 		// Advertise/Publish vtol vehicle status
 		_vtol_vehicle_status.airspeed_filtered = get_filtered_airspeed();
 		_vtol_vehicle_status.mc_weights[0] = _vtol_type->get_mc_roll_weight();
 		_vtol_vehicle_status.mc_weights[1] = _vtol_type->get_mc_pitch_weight();
 		_vtol_vehicle_status.mc_weights[2] = _vtol_type->get_mc_yaw_weight();
 		_vtol_vehicle_status.mc_weights[3] = _vtol_type->get_mc_throttle_weight();
-		_vtol_vehicle_status.lookahead_pitch = _vtol_type->get_qc_lookahead_pitch();
-		_vtol_vehicle_status.lookahead_roll = _vtol_type->get_qc_lookahead_roll();
+		_vtol_vehicle_status.lookahead_pitch = _qc_lookahead_pitch.getState();
+		_vtol_vehicle_status.lookahead_roll = _qc_lookahead_roll.getState();
 		_vtol_vehicle_status.timestamp = hrt_absolute_time();
 		_vtol_vehicle_status_pub.publish(_vtol_vehicle_status);
 
@@ -516,6 +518,42 @@ void VtolAttitudeControl::update_airspeed_filter(const struct airspeed_validated
 	}
 
 	_airspeed_filter_last_timestamp = sample.timestamp;
+}
+
+void VtolAttitudeControl::update_qc_lookahead_angles()
+{
+	const hrt_abstime now = hrt_absolute_time();
+	const float dt = math::constrain((now - _qc_lookahead_last_ts) / 1e6f, 0.001f, 0.1f);
+	_qc_lookahead_last_ts = now;
+
+	const float time_constant = _param_vt_fw_qc_la_ft.get() / 1000.0f;
+	_qc_lookahead_pitch.setParameters(dt, time_constant);
+	_qc_lookahead_roll.setParameters(dt, time_constant);
+
+	const float p = _vehicle_angular_velocity.xyz[0];
+	const float q = _vehicle_angular_velocity.xyz[1];
+	const float r = _vehicle_angular_velocity.xyz[2];
+
+	const matrix::Eulerf euler(matrix::Quatf(_vehicle_attitude.q));
+
+	if (!PX4_ISFINITE(p) || !PX4_ISFINITE(q) || !PX4_ISFINITE(r)) {
+		_qc_lookahead_pitch.reset(euler.theta());
+		_qc_lookahead_roll.reset(euler.phi());
+		return;
+	}
+
+	constexpr float MAX_PITCH_FOR_TAN = math::radians(89.f);
+	const float theta = math::constrain(euler.theta(), -MAX_PITCH_FOR_TAN, MAX_PITCH_FOR_TAN);
+	const float phi = euler.phi();
+
+	const float euler_pitch_rate = q * cosf(phi) - r * sinf(phi);
+	const float euler_roll_rate = p + (q * sinf(phi) + r * cosf(phi)) * tanf(theta);
+
+	const float unfiltered_pitch = euler.theta() + _param_vt_fw_qc_la_pt.get() * 0.001f * euler_pitch_rate;
+	const float unfiltered_roll = euler.phi() + _param_vt_fw_qc_la_rt.get() * 0.001f * euler_roll_rate;
+
+	_qc_lookahead_pitch.update(unfiltered_pitch);
+	_qc_lookahead_roll.update(unfiltered_roll);
 }
 
 int

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -131,6 +131,8 @@ public:
 
 	struct airspeed_validated_s 			*get_airspeed() {return &_airspeed_validated;}
 	const float                    			&get_filtered_airspeed() { return _airspeed_filter.getState(); }
+	const float                    			&get_qc_lookahead_pitch() { return _qc_lookahead_pitch.getState(); }
+	const float                    			&get_qc_lookahead_roll() { return _qc_lookahead_roll.getState(); }
 	struct position_setpoint_triplet_s		*get_pos_sp_triplet() {return &_pos_sp_triplet;}
 	struct tecs_status_s 				*get_tecs_status() {return &_tecs_status;}
 	struct vehicle_attitude_s 			*get_att() {return &_vehicle_attitude;}
@@ -152,6 +154,7 @@ public:
 private:
 	void Run() override;
 	void update_airspeed_filter(const struct airspeed_validated_s &sample);
+	void update_qc_lookahead_angles();
 
 	uORB::SubscriptionCallbackWorkItem _vehicle_torque_setpoint_virtual_fw_sub{this, ORB_ID(vehicle_torque_setpoint_virtual_fw)};
 	uORB::SubscriptionCallbackWorkItem _vehicle_torque_setpoint_virtual_mc_sub{this, ORB_ID(vehicle_torque_setpoint_virtual_mc)};
@@ -190,6 +193,10 @@ private:
 
 	AlphaFilter<float> _airspeed_filter;
 	hrt_abstime _airspeed_filter_last_timestamp{0};
+
+	AlphaFilter<float> _qc_lookahead_pitch;
+	AlphaFilter<float> _qc_lookahead_roll;
+	hrt_abstime _qc_lookahead_last_ts{0};
 
 	vehicle_attitude_setpoint_s		_vehicle_attitude_sp{};	// vehicle attitude setpoint
 	vehicle_attitude_setpoint_s 		_fw_virtual_att_sp{};	// virtual fw attitude setpoint
@@ -250,6 +257,9 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::VT_TYPE>) _param_vt_type,
 		(ParamFloat<px4::params::VT_SPOILER_MC_LD>) _param_vt_spoiler_mc_ld,
-		(ParamFloat<px4::params::VT_ARSP_TAU>) _param_vt_arsp_tau
+		(ParamFloat<px4::params::VT_ARSP_TAU>) _param_vt_arsp_tau,
+		(ParamInt<px4::params::VT_FW_QC_LA_PT>) _param_vt_fw_qc_la_pt,
+		(ParamInt<px4::params::VT_FW_QC_LA_RT>) _param_vt_fw_qc_la_rt,
+		(ParamInt<px4::params::VT_FW_QC_LA_FT>) _param_vt_fw_qc_la_ft
 	)
 };

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -264,14 +264,14 @@ PARAM_DEFINE_INT32(VT_FW_QC_R, 0);
  * Should not be much larger than the pitch time constant, otherwise it will trigger from
  * normal pitching maneuvers. Set to 0 to disable.
  *
- * @unit s
- * @min 0.0
- * @max 1.0
- * @decimal 2
- * @increment 0.01
+ * @unit ms
+ * @min 0
+ * @max 1000
+ * @decimal 0
+ * @increment 10
  * @group VTOL Attitude Control
  */
-PARAM_DEFINE_FLOAT(VT_FW_QC_P_LA, 0.0f);
+PARAM_DEFINE_INT32(VT_FW_QC_LA_PT, 0);
 
 /**
  * Quad-chute roll lookahead time
@@ -282,14 +282,31 @@ PARAM_DEFINE_FLOAT(VT_FW_QC_P_LA, 0.0f);
  * Should not be much larger than the roll time constant, otherwise it will trigger from
  * normal rolling maneuvers. Set to 0 to disable.
  *
- * @unit s
- * @min 0.0
- * @max 1.0
- * @decimal 2
- * @increment 0.01
+ * @unit ms
+ * @min 0
+ * @max 1000
+ * @decimal 0
+ * @increment 10
  * @group VTOL Attitude Control
  */
-PARAM_DEFINE_FLOAT(VT_FW_QC_R_LA, 0.0f);
+PARAM_DEFINE_INT32(VT_FW_QC_LA_RT, 0);
+
+/**
+ * Quad-chute lookahead filter time
+ *
+ * Low-pass filter time constant for the lookahead pitch and roll angles.  A
+ * larger value reduces the chance of false positives due to gyro noise, at the
+ * cost of slower reaction time.
+ * Set to 0 to disable filtering.
+ *
+ * @unit ms
+ * @min 0
+ * @max 100
+ * @decimal 0
+ * @increment 1
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_INT32(VT_FW_QC_LA_FT, 10);
 
 /**
  * Quad-chute maximum height

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -111,8 +111,6 @@ void VtolType::update_mc_state()
 	_mc_pitch_weight = 1.0f;
 	_mc_yaw_weight = 1.0f;
 	_mc_throttle_weight = 1.0f;
-	_qc_lookahead_pitch = 0.0f;
-	_qc_lookahead_roll = 0.0f;
 }
 
 void VtolType::update_fw_state()
@@ -362,51 +360,28 @@ bool VtolType::isRollExceeded()
 	return false;
 }
 
-void VtolType::update_qc_lookahead_angles()
-{
-	const float p = _vehicle_angular_velocity->xyz[0];
-	const float q = _vehicle_angular_velocity->xyz[1];
-	const float r = _vehicle_angular_velocity->xyz[2];
-
-	if (!PX4_ISFINITE(p) || !PX4_ISFINITE(q) || !PX4_ISFINITE(r)) {
-		_qc_lookahead_pitch = NAN;
-		_qc_lookahead_roll = NAN;
-		return;
-	}
-
-	const Eulerf euler(Quatf(_v_att->q));
-	const float phi = euler.phi();
-
-	constexpr float MAX_PITCH_FOR_TAN = math::radians(89.f);
-	const float theta = math::constrain(euler.theta(), -MAX_PITCH_FOR_TAN, MAX_PITCH_FOR_TAN);
-
-	const float euler_pitch_rate = q * cosf(phi) - r * sinf(phi);
-	const float euler_roll_rate = p + (q * sinf(phi) + r * cosf(phi)) * tanf(theta);
-
-	_qc_lookahead_pitch = euler.theta() + _param_vt_fw_qc_p_la.get() * euler_pitch_rate;
-	_qc_lookahead_roll = euler.phi() + _param_vt_fw_qc_r_la.get() * euler_roll_rate;
-}
-
 bool VtolType::isPitchExceededLookahead()
 {
 	const float threshold_deg = static_cast<float>(_param_vt_fw_qc_p.get());
+	const float lookahead_pitch = _attc->get_qc_lookahead_pitch();
 
-	if (threshold_deg <= FLT_EPSILON || !PX4_ISFINITE(_qc_lookahead_pitch)) {
+	if (threshold_deg <= FLT_EPSILON || !PX4_ISFINITE(lookahead_pitch)) {
 		return false;
 	}
 
-	return fabsf(_qc_lookahead_pitch) > math::radians(threshold_deg);
+	return fabsf(lookahead_pitch) > math::radians(threshold_deg);
 }
 
 bool VtolType::isRollExceededLookahead()
 {
 	const float threshold_deg = static_cast<float>(_param_vt_fw_qc_r.get());
+	const float lookahead_roll = _attc->get_qc_lookahead_roll();
 
-	if (threshold_deg <= FLT_EPSILON || !PX4_ISFINITE(_qc_lookahead_roll)) {
+	if (threshold_deg <= FLT_EPSILON || !PX4_ISFINITE(lookahead_roll)) {
 		return false;
 	}
 
-	return fabsf(_qc_lookahead_roll) > math::radians(threshold_deg);
+	return fabsf(lookahead_roll) > math::radians(threshold_deg);
 }
 
 bool VtolType::isFrontTransitionTimeout()
@@ -476,7 +451,6 @@ void VtolType::handleSpecialExternalCommandQuadchute()
 void VtolType::check_quadchute_condition()
 {
 	handleSpecialExternalCommandQuadchute();
-	update_qc_lookahead_angles();
 
 	if (isQuadchuteEnabled()) {
 		QuadchuteReason reason = getQuadchuteReason();

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -212,7 +212,6 @@ public:
 	 * Checks for fixed-wing failsafe condition and issues abort request if needed.
 	 */
 	void check_quadchute_condition();
-	void update_qc_lookahead_angles();
 
 	/**
 	 * Returns true if we're allowed to do a mode transition on the ground.
@@ -226,8 +225,6 @@ public:
 	float get_mc_pitch_weight() const { return _mc_pitch_weight; }
 	float get_mc_yaw_weight() const { return _mc_yaw_weight; }
 	float get_mc_throttle_weight() const { return _mc_throttle_weight; }
-	float get_qc_lookahead_pitch() const { return _qc_lookahead_pitch; }
-	float get_qc_lookahead_roll() const { return _qc_lookahead_roll; }
 
 	/**
 	 * Pusher assist in hover (pusher/pull for standard VTOL, motor tilt for tiltrotor)
@@ -313,8 +310,6 @@ protected:
 	float _mc_pitch_weight = 1.0f;	// weight for multicopter attitude controller pitch output
 	float _mc_yaw_weight = 1.0f;	// weight for multicopter attitude controller yaw output
 	float _mc_throttle_weight = 1.0f;	// weight for multicopter throttle command. Used to avoid
-	float _qc_lookahead_pitch = 0.0f;
-	float _qc_lookahead_roll = 0.0f;
 
 	// motors spinning up or cutting too fast when doing transitions.
 	float _thrust_transition = 0.0f;	// thrust value applied during a front transition (tailsitter & tiltrotor only)
@@ -350,8 +345,6 @@ protected:
 					(ParamFloat<px4::params::VT_QC_ALT_LOSS>) _param_vt_qc_alt_loss,
 					(ParamInt<px4::params::VT_FW_QC_P>) _param_vt_fw_qc_p,
 					(ParamInt<px4::params::VT_FW_QC_R>) _param_vt_fw_qc_r,
-					(ParamFloat<px4::params::VT_FW_QC_P_LA>) _param_vt_fw_qc_p_la,
-					(ParamFloat<px4::params::VT_FW_QC_R_LA>) _param_vt_fw_qc_r_la,
 					(ParamFloat<px4::params::VT_QC_T_ALT_LOSS>) _param_vt_qc_t_alt_loss,
 					(ParamInt<px4::params::VT_FW_QC_HMAX>) _param_quadchute_max_height,
 					(ParamFloat<px4::params::VT_F_TR_OL_TM>) _param_vt_f_tr_ol_tm,


### PR DESCRIPTION
Avoids false lookahead QuadCHute triggers in delivery back-transition, see [log checks](https://metabase.aviant.no/question?end_date=&include_type=&exclude_type=ground_test&flight_mode=FIXEDWING%7CFORWARD_TRANSITION%7CBACK_TRANSITION&statistic=la500_maxabs&aircraft_name=NT15%7CNT16%7CNT17%7CNT18&field=roll&oneliner_exclude=&start_date=&oneliner_include=#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjo3LCJ0eXBlIjoibmF0aXZlIiwibmF0aXZlIjp7InRlbXBsYXRlLXRhZ3MiOnsiZW5kX2RhdGUiOnsidHlwZSI6ImRhdGUiLCJuYW1lIjoiZW5kX2RhdGUiLCJpZCI6IjNlMDgyNzZiLWZmYmEtNDRlMi1iNWVjLTIzYTc2YmI4OWU0ZiIsImRpc3BsYXktbmFtZSI6IkVuZCBEYXRlIn0sImluY2x1ZGVfdHlwZSI6eyJ0eXBlIjoidGV4dCIsIm5hbWUiOiJpbmNsdWRlX3R5cGUiLCJpZCI6IjdkMGM0MzVkLWVlYWMtNDFlYS1hMjQ5LTJkYWI2OTQ5N2M0NCIsImRpc3BsYXktbmFtZSI6IkluY2x1ZGUgVHlwZSIsInJlcXVpcmVkIjpmYWxzZX0sImV4Y2x1ZGVfdHlwZSI6eyJ0eXBlIjoidGV4dCIsIm5hbWUiOiJleGNsdWRlX3R5cGUiLCJpZCI6IjEzNjc3NjhhLWVlNDYtNDJmNS1hMTg4LWZjMjFjMDA5MzM4ZCIsImRpc3BsYXktbmFtZSI6IkV4Y2x1ZGUgVHlwZSJ9LCJmbGlnaHRfbW9kZSI6eyJ0eXBlIjoidGV4dCIsIm5hbWUiOiJmbGlnaHRfbW9kZSIsImlkIjoiZjQ4N2RlNDYtZjA4NC00YzVmLWE4ZGItYzAwZWQzMWU3ZDUwIiwiZGlzcGxheS1uYW1lIjoiRmxpZ2h0IE1vZGUifSwic3RhdGlzdGljIjp7InR5cGUiOiJ0ZXh0IiwibmFtZSI6InN0YXRpc3RpYyIsImlkIjoiZTY4MzRiNjEtOGE1ZS00ZjM5LWFiYjMtM2YzOWRmZDNhNmZkIiwiZGlzcGxheS1uYW1lIjoiU3RhdGlzdGljIiwiZGVmYXVsdCI6WyJpbnN0YW5jZV9jaGFuZ2VzIl0sInJlcXVpcmVkIjp0cnVlfSwiYWlyY3JhZnRfbmFtZSI6eyJ0eXBlIjoidGV4dCIsIm5hbWUiOiJhaXJjcmFmdF9uYW1lIiwiaWQiOiIzZjI3Njk5Yy1lYzJiLTQ2YzctOGE1NC1jZDJiMWE2NjZlOTAiLCJkaXNwbGF5LW5hbWUiOiJBaXJjcmFmdCBOYW1lIn0sImZpZWxkIjp7InR5cGUiOiJ0ZXh0IiwibmFtZSI6ImZpZWxkIiwiaWQiOiJjNjZhOWU3NS02M2NiLTRmZmItYmY5OS00YzZmMDg5ZDRmY2MiLCJkaXNwbGF5LW5hbWUiOiJGaWVsZCJ9LCJvbmVsaW5lcl9leGNsdWRlIjp7InR5cGUiOiJ0ZXh0IiwibmFtZSI6Im9uZWxpbmVyX2V4Y2x1ZGUiLCJpZCI6ImI2OTVmNDQ4LTgxMmUtNDZmOC04OTQzLWI4YjQ4MjM4NDMyNCIsImRpc3BsYXktbmFtZSI6Ik9uZWxpbmVyIEV4Y2x1ZGUifSwic3RhcnRfZGF0ZSI6eyJ0eXBlIjoiZGF0ZSIsIm5hbWUiOiJzdGFydF9kYXRlIiwiaWQiOiIwY2I4OWZmYS05MTUzLTRiNjYtOGI0Mi0zZjVkNjczMjFlMjMiLCJkaXNwbGF5LW5hbWUiOiJTdGFydCBEYXRlIiwicmVxdWlyZWQiOmZhbHNlfSwib25lbGluZXJfaW5jbHVkZSI6eyJ0eXBlIjoidGV4dCIsIm5hbWUiOiJvbmVsaW5lcl9pbmNsdWRlIiwiaWQiOiIwZjZmZWFiYi0yOWQ5LTRlYzYtOGFjNC00NzI0YTYyMDdjZWIiLCJkaXNwbGF5LW5hbWUiOiJPbmVsaW5lciBJbmNsdWRlIn19LCJxdWVyeSI6IldJVEggbGF0ZXN0X3N1aXRlX3J1bnMgQVMgKFxuICAgIFNFTEVDVFxuICAgICAgICBESVNUSU5DVCBPTihmLnN0YXJ0X3RpbWUsIGxjc3IubG9nX2NoZWNrX3N1aXRlX25hbWUpXG4gICAgICAgIGYuaWQgXCJmbGlnaHRfaWRcIixcbiAgICAgICAgbGNzci5pZCxcbiAgICAgICAgbGNzci5sb2dfY2hlY2tfc3VpdGVfbmFtZVxuICAgIEZST00gZmxpZ2h0X2xvZ2dpbmdfbG9nY2hlY2tzdWl0ZXJ1biBsY3NyXG4gICAgICAgIEpPSU4gZmxpZ2h0X2xvZ2dpbmdfZmxpZ2h0IGYgT04gbGNzci5mbGlnaHRfaWQgPSBmLmlkXG4gICAgV0hFUkUgbGNzci5maW5pc2hlZCBJUyBOT1QgTlVMTCBBTkQgZi5zdGFydF90aW1lIElTIE5PVCBOVUxMXG4gICAgT1JERVIgQlkgZi5zdGFydF90aW1lIERFU0MsIGxjc3IubG9nX2NoZWNrX3N1aXRlX25hbWUgREVTQywgbGNzci5maW5pc2hlZCBERVNDXG4pXG5TRUxFQ1RcbiAgICBERU5TRV9SQU5LKCkgT1ZFUiAoUEFSVElUSU9OIEJZIGEubmFtZSBPUkRFUiBCWSBmLmlkKSBBUyBcIkZsaWdodCBzZXF1ZW5jZVwiLFxuICAgIGYuc3RhcnRfdGltZSBBUyBcIlRpbWVcIixcbiAgICBsY3J2LnZhbHVlX251bWJlciBBUyBcIlZhbHVlXCIsXG4gICAgYS5uYW1lIHx8ICdfJyB8fCBsY3J2Lm5hbWUgQVMgXCJJZGVudGlmaWVyXCIsXG4gICAgZi5pZCBBUyBcIkZsaWdodCBJRFwiLFxuICAgIGYubmFtZSBBUyBcIkZsaWdodCBuYW1lXCIsXG4gICAgZi5vbmVsaW5lciBBUyBcIk9uZWxpbmVyXCIsXG4gICAgbGNzci5sb2dfY2hlY2tfc3VpdGVfbmFtZSBBUyBcIlN1aXRlXCIsXG4gICAgbGNzci5pZFxuRlJPTSBmbGlnaHRfbG9nZ2luZ19sb2djaGVja3J1biBsY3JcbiAgICBKT0lOIGxhdGVzdF9zdWl0ZV9ydW5zIGxjc3IgT04gbGNyLmxvZ19jaGVja19zdWl0ZV9ydW5faWQgPSBsY3NyLmlkXG4gICAgSk9JTiBmbGlnaHRfbG9nZ2luZ19mbGlnaHQgZiBPTiBsY3NyLmZsaWdodF9pZCA9IGYuaWRcbiAgICBKT0lOIGZsaWdodF9sb2dnaW5nX2FpcmNyYWZ0IGEgT04gZi5haXJjcmFmdF9pZCA9IGEuaWRcbiAgICBKT0lOIGZsaWdodF9sb2dnaW5nX2xvZ2NoZWNrcnVudmFsdWUgbGNydiBPTiBsY3J2LmxvZ19jaGVja19ydW5faWQgPSBsY3IuaWRcbiAgICBKT0lOIGZsaWdodF9sb2dnaW5nX2xvZ2NoZWNrIGxjIE9OIGxjci5sb2dfY2hlY2tfaWQgPSBsYy5pZFxuV0hFUkVcbiAgICBsYy5uYW1lID0gJ2F0dGl0dWRlX2VzdGltYXRlcydcbiAgICBbW0FORCBsY3J2Lm5hbWUgfiB7e2ZpZWxkfX1dXVxuICAgIFtbQU5EIGxjcnYubmFtZSB-IHt7c3RhdGlzdGljfX1dXVxuICAgIFtbQU5EIGxjcnYubmFtZSB-IHt7ZmxpZ2h0X21vZGV9fV1dXG5cdEFORCBsY3J2Lm5hbWUgIX4gJ2FjY2VsJ1xuICAgIFtbQU5EIGEubmFtZSB-IHt7YWlyY3JhZnRfbmFtZX19XV1cbiAgICBbW0FORCBmLnN0YXJ0X3RpbWU6OmRhdGUgPj0ge3tzdGFydF9kYXRlfX06OmRhdGVdXVxuICAgIFtbQU5EIGYuZW5kX3RpbWU6OmRhdGUgPD0ge3tlbmRfZGF0ZX19OjpkYXRlXV1cbiAgICBbW0FORCBmLm9uZWxpbmVyIH4ge3tvbmVsaW5lcl9pbmNsdWRlfX1dXVxuICAgIFtbQU5EIGxjc3IubG9nX2NoZWNrX3N1aXRlX25hbWUgPSB7e2luY2x1ZGVfdHlwZX19XV1cbiAgICBbW0FORCBsY3NyLmxvZ19jaGVja19zdWl0ZV9uYW1lICE9IHt7ZXhjbHVkZV90eXBlfX1dXVxuICAgIFtbQU5EIGYub25lbGluZXIgIX4ge3tvbmVsaW5lcl9leGNsdWRlfX1dXVxuT1JERVIgQlkgXCJGbGlnaHQgc2VxdWVuY2VcIiJ9fSwiZGlzcGxheSI6ImxpbmUiLCJkaXNwbGF5SXNMb2NrZWQiOnRydWUsInBhcmFtZXRlcnMiOlt7ImlkIjoiM2UwODI3NmItZmZiYS00NGUyLWI1ZWMtMjNhNzZiYjg5ZTRmIiwidHlwZSI6ImRhdGUvc2luZ2xlIiwidGFyZ2V0IjpbInZhcmlhYmxlIixbInRlbXBsYXRlLXRhZyIsImVuZF9kYXRlIl1dLCJuYW1lIjoiRW5kIERhdGUiLCJzbHVnIjoiZW5kX2RhdGUifSx7ImlkIjoiN2QwYzQzNWQtZWVhYy00MWVhLWEyNDktMmRhYjY5NDk3YzQ0IiwidHlwZSI6ImNhdGVnb3J5IiwidGFyZ2V0IjpbInZhcmlhYmxlIixbInRlbXBsYXRlLXRhZyIsImluY2x1ZGVfdHlwZSJdXSwibmFtZSI6IkluY2x1ZGUgVHlwZSIsInNsdWciOiJpbmNsdWRlX3R5cGUiLCJyZXF1aXJlZCI6ZmFsc2UsInZhbHVlc19xdWVyeV90eXBlIjoibGlzdCIsInZhbHVlc19zb3VyY2VfdHlwZSI6InN0YXRpYy1saXN0IiwidmFsdWVzX3NvdXJjZV9jb25maWciOnsidmFsdWVzIjpbImdyb3VuZF90ZXN0Iiwib25kZW1hbmRfZGVsaXZlcnkiLCJ0ZWNobmljYWxfdGVzdHMiXX19LHsiaWQiOiIxMzY3NzY4YS1lZTQ2LTQyZjUtYTE4OC1mYzIxYzAwOTMzOGQiLCJ0eXBlIjoiY2F0ZWdvcnkiLCJ0YXJnZXQiOlsidmFyaWFibGUiLFsidGVtcGxhdGUtdGFnIiwiZXhjbHVkZV90eXBlIl1dLCJuYW1lIjoiRXhjbHVkZSBUeXBlIiwic2x1ZyI6ImV4Y2x1ZGVfdHlwZSIsInZhbHVlc19xdWVyeV90eXBlIjoibGlzdCIsInZhbHVlc19zb3VyY2VfdHlwZSI6InN0YXRpYy1saXN0IiwidmFsdWVzX3NvdXJjZV9jb25maWciOnsidmFsdWVzIjpbImdyb3VuZF90ZXN0IiwidGVjaG5pY2FsX3Rlc3QiLCJvbmRlbWFuZF9kZWxpdmVyeSJdfX0seyJpZCI6ImY0ODdkZTQ2LWYwODQtNGM1Zi1hOGRiLWMwMGVkMzFlN2Q1MCIsInR5cGUiOiJjYXRlZ29yeSIsInRhcmdldCI6WyJ2YXJpYWJsZSIsWyJ0ZW1wbGF0ZS10YWciLCJmbGlnaHRfbW9kZSJdXSwibmFtZSI6IkZsaWdodCBNb2RlIiwic2x1ZyI6ImZsaWdodF9tb2RlIiwidmFsdWVzX3F1ZXJ5X3R5cGUiOiJsaXN0IiwidmFsdWVzX3NvdXJjZV90eXBlIjoic3RhdGljLWxpc3QiLCJ2YWx1ZXNfc291cmNlX2NvbmZpZyI6eyJ2YWx1ZXMiOltbIk1VTFRJUk9UT1IiXSxbIkZJWEVEV0lORyJdLFsiRk9SV0FSRF9UUkFOU0lUSU9OIl0sWyJCQUNLX1RSQU5TSVRJT04iXSxbIkZJWEVEV0lOR3xGT1JXQVJEX1RSQU5TSVRJT058QkFDS19UUkFOU0lUSU9OIl1dfX0seyJpZCI6ImU2ODM0YjYxLThhNWUtNGYzOS1hYmIzLTNmMzlkZmQzYTZmZCIsInR5cGUiOiJjYXRlZ29yeSIsInRhcmdldCI6WyJ2YXJpYWJsZSIsWyJ0ZW1wbGF0ZS10YWciLCJzdGF0aXN0aWMiXV0sIm5hbWUiOiJTdGF0aXN0aWMiLCJzbHVnIjoic3RhdGlzdGljIiwiZGVmYXVsdCI6WyJpbnN0YW5jZV9jaGFuZ2VzIl0sInJlcXVpcmVkIjp0cnVlLCJ2YWx1ZXNfcXVlcnlfdHlwZSI6Imxpc3QiLCJ2YWx1ZXNfc291cmNlX3R5cGUiOiJzdGF0aWMtbGlzdCIsInZhbHVlc19zb3VyY2VfY29uZmlnIjp7InZhbHVlcyI6W1sicGN0NTAiXSxbImlxcjUwIl0sWyJpcXIxMDAiXSxbIm1heGFicyJdLFsiW14wXV9tYXhhYnMiXSxbImxhMTAwX21heGFicyJdLFsibGEyNTBfbWF4YWJzIl0sWyJsYTUwMF9tYXhhYnMiXSxbImxhNzUwX21heGFicyJdLFsibGExMDAwX21heGFicyJdLFsibGExNTAwX21heGFicyJdLFsiKGxhWzAtOV0rXyk_bWF4YWJzIl0sWyJsYTUwMF9tYXhhYnN8W14wXV9tYXhhYnMiXV19fSx7ImlkIjoiM2YyNzY5OWMtZWMyYi00NmM3LThhNTQtY2QyYjFhNjY2ZTkwIiwidHlwZSI6ImNhdGVnb3J5IiwidGFyZ2V0IjpbInZhcmlhYmxlIixbInRlbXBsYXRlLXRhZyIsImFpcmNyYWZ0X25hbWUiXV0sIm5hbWUiOiJBaXJjcmFmdCBOYW1lIiwic2x1ZyI6ImFpcmNyYWZ0X25hbWUiLCJ2YWx1ZXNfcXVlcnlfdHlwZSI6Im5vbmUiLCJ2YWx1ZXNfc291cmNlX3R5cGUiOiJjYXJkIiwidmFsdWVzX3NvdXJjZV9jb25maWciOnsiY2FyZF9pZCI6NTM1LCJ2YWx1ZV9maWVsZCI6WyJmaWVsZCIsNzIxOCx7ImJhc2UtdHlwZSI6InR5cGUvVGV4dCJ9XX19LHsiaWQiOiJjNjZhOWU3NS02M2NiLTRmZmItYmY5OS00YzZmMDg5ZDRmY2MiLCJ0eXBlIjoiY2F0ZWdvcnkiLCJ0YXJnZXQiOlsidmFyaWFibGUiLFsidGVtcGxhdGUtdGFnIiwiZmllbGQiXV0sIm5hbWUiOiJGaWVsZCIsInNsdWciOiJmaWVsZCIsInZhbHVlc19xdWVyeV90eXBlIjoibGlzdCIsInZhbHVlc19zb3VyY2VfdHlwZSI6InN0YXRpYy1saXN0IiwidmFsdWVzX3NvdXJjZV9jb25maWciOnsidmFsdWVzIjpbInJvbGwiLCJwaXRjaCIsInlhdyIsInRpbHQiXX19LHsiaWQiOiJiNjk1ZjQ0OC04MTJlLTQ2ZjgtODk0My1iOGI0ODIzODQzMjQiLCJ0eXBlIjoiY2F0ZWdvcnkiLCJ0YXJnZXQiOlsidmFyaWFibGUiLFsidGVtcGxhdGUtdGFnIiwib25lbGluZXJfZXhjbHVkZSJdXSwibmFtZSI6Ik9uZWxpbmVyIEV4Y2x1ZGUiLCJzbHVnIjoib25lbGluZXJfZXhjbHVkZSJ9LHsiaWQiOiIwY2I4OWZmYS05MTUzLTRiNjYtOGI0Mi0zZjVkNjczMjFlMjMiLCJ0eXBlIjoiZGF0ZS9zaW5nbGUiLCJ0YXJnZXQiOlsidmFyaWFibGUiLFsidGVtcGxhdGUtdGFnIiwic3RhcnRfZGF0ZSJdXSwibmFtZSI6IlN0YXJ0IERhdGUiLCJzbHVnIjoic3RhcnRfZGF0ZSIsInJlcXVpcmVkIjpmYWxzZX0seyJpZCI6IjBmNmZlYWJiLTI5ZDktNGVjNi04YWM0LTQ3MjRhNjIwN2NlYiIsInR5cGUiOiJjYXRlZ29yeSIsInRhcmdldCI6WyJ2YXJpYWJsZSIsWyJ0ZW1wbGF0ZS10YWciLCJvbmVsaW5lcl9pbmNsdWRlIl1dLCJuYW1lIjoiT25lbGluZXIgSW5jbHVkZSIsInNsdWciOiJvbmVsaW5lcl9pbmNsdWRlIn1dLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7ImdyYXBoLnNob3dfZ29hbCI6dHJ1ZSwiZ3JhcGgueV9heGlzLnRpdGxlX3RleHQiOiJWYWx1ZSAoZGVnKSIsImdyYXBoLnNob3dfdmFsdWVzIjpmYWxzZSwidGFibGUuY2VsbF9jb2x1bW4iOiJzdGFydGVkIiwiZ3JhcGguZ29hbF9sYWJlbCI6Ijc1IGRlZyIsImdyYXBoLnlfYXhpcy5tYXgiOjIwLCJncmFwaC5zZXJpZXNfb3JkZXJfZGltZW5zaW9uIjpudWxsLCJncmFwaC55X2F4aXMubGFiZWxzX2VuYWJsZWQiOnRydWUsImdyYXBoLmdvYWxfdmFsdWUiOjc1LCJncmFwaC55X2F4aXMuc2NhbGUiOiJsaW5lYXIiLCJncmFwaC55X2F4aXMuYXV0b19zcGxpdCI6ZmFsc2UsImdyYXBoLm1ldHJpY3MiOlsiVmFsdWUiXSwiZ3JhcGgudG9vbHRpcF9jb2x1bW5zIjpbIltcIm5hbWVcIixcIk9uZWxpbmVyXCJdIiwiW1wibmFtZVwiLFwiVGltZVwiXSIsIltcIm5hbWVcIixcIkZsaWdodCBJRFwiXSJdLCJncmFwaC5zZXJpZXNfb3JkZXIiOm51bGwsImNvbHVtbl9zZXR0aW5ncyI6eyJbXCJuYW1lXCIsXCJUaW1lXCJdIjp7InRpbWVfZW5hYmxlZCI6bnVsbH19LCJncmFwaC55X2F4aXMuYXV0b19yYW5nZSI6dHJ1ZSwiZ3JhcGgueF9heGlzLnNjYWxlIjoibGluZWFyIiwiZ3JhcGguZGltZW5zaW9ucyI6WyJGbGlnaHQgc2VxdWVuY2UiLCJJZGVudGlmaWVyIl0sImdyYXBoLnlfYXhpcy5taW4iOjAsImdyYXBoLmxhYmVsX3ZhbHVlX2Zvcm1hdHRpbmciOiJhdXRvIn0sIm9yaWdpbmFsX2NhcmRfaWQiOjU1NCwidHlwZSI6InF1ZXN0aW9uIn0=) from Foodora.

This PR solves this with an alpha-filter on the lookahead angles.

To make that nice in code, I moved the looakhead calculation to vtol_att_control, and just do the QuadChute triggering in vtol_type based on that value.

Also changed some parameter names and unit because it's nicer, and removes some unnecessary logging code
