### PR TITLE
Fix intermittent wrong pause location

### DIFF
--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -337,6 +337,8 @@ private:
 	hrt_abstime _last_geofence_check = 0;
 
 	hrt_abstime _wait_for_vehicle_status_timestamp{0}; /**< If non-zero, wait for vehicle_status update before processing next cmd */
+	bool _wait_for_nav_state_auto_loiter{false}; /**< If true, wait for vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER  */
+	uint8_t _wait_for_nav_state_auto_loiter_counter{0};
 
 	bool		_geofence_reposition_sent{false};		/**< flag if reposition command has been sent for current geofence breach*/
 	hrt_abstime	_time_loitering_after_gf_breach{0};		/**< timestamp of when loitering after a geofence breach was started */

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -242,7 +242,7 @@ void Navigator::run()
 		// Handle Vehicle commands
 		int vehicle_command_updates = 0;
 
-		while (_wait_for_vehicle_status_timestamp == 0 && _vehicle_command_sub.updated()
+		while (!_wait_for_nav_state_auto_loiter && _wait_for_vehicle_status_timestamp == 0 && _vehicle_command_sub.updated()
 		       && (vehicle_command_updates < vehicle_command_s::ORB_QUEUE_LENGTH)) {
 			vehicle_command_updates++;
 			const unsigned last_generation = _vehicle_command_sub.get_last_generation();
@@ -267,6 +267,8 @@ void Navigator::run()
 
 				// Wait for vehicle_status before handling the next command, otherwise the setpoint could be overwritten
 				_wait_for_vehicle_status_timestamp = hrt_absolute_time();
+				_wait_for_nav_state_auto_loiter = true;
+				_wait_for_nav_state_auto_loiter_counter = 0;
 
 				vehicle_global_position_s position_setpoint{};
 
@@ -882,6 +884,21 @@ void Navigator::run()
 
 		if (_wait_for_vehicle_status_timestamp != 0 && _vstatus.timestamp > _wait_for_vehicle_status_timestamp) {
 			_wait_for_vehicle_status_timestamp = 0;
+		}
+
+
+		if (_wait_for_nav_state_auto_loiter && _vstatus.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER) {
+			_wait_for_nav_state_auto_loiter = false;
+
+		} else if (_wait_for_nav_state_auto_loiter) {
+			//This is a guard mechanism.
+			++_wait_for_nav_state_auto_loiter_counter;
+
+			// In the worst case, it should not take more than two loops. We wait for five before resetting the flag.
+			if (_wait_for_nav_state_auto_loiter_counter >= 5) {
+				PX4_WARN("_wait_for_nav_state_auto_loiter flag reset");
+				_wait_for_nav_state_auto_loiter = false;
+			}
 		}
 
 		/* iterate through navigation modes and set active/inactive for each */


### PR DESCRIPTION
Fix for the issue where a **PAUSE** command issued through **QGC** results in the vehicle pausing (loitering) at the next waypoint instead of at the location where the pause was pressed.

Solution is a workaround for a race condition between the commander and navigator when the navigator receives VEHICLE_CMD_DO_REPOSITION.

For repositioning to work properly, the navigator receives two VEHICLE_CMD_DO_REPOSITION commands. In the race condition, the triplets were reset in the navigator logic before the second reposition command arrived. For the logic to work correctly, the commander must change the navigation state in vehicle_status_s to NAVIGATION_STATE_AUTO_LOITER before the second reposition command is processed by the navigator.

To keep this workaround as simple as possible,  flag is added that blocks command processing until the commander changes the state. In testing, when the issue appeared, the old logic failed rarely inside one additional navigator loop.

Additionally, for safety reasons, a guard is added in case something goes wrong with the commander and the navigation state in vehicle_status_s never changes, although this is not expected.