### PR TITLE
fix(mavlink): resolve warnings from TRN mavlink mode

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1468,9 +1468,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 			configure_stream_local("LOCAL_POSITION_NED", 10.0f);
 			configure_stream_local("GLOBAL_POSITION_INT", 10.f);
 			configure_stream_local("GPS_RAW_INT", 10.0f);
-			configure_stream_local("RAW_PRESSURE", 10.0f);
 			configure_stream_local("SCALED_PRESSURE", 10.0f);
-			configure_stream_local("RAW_IMU", 10.0f);
 			configure_stream_local("ODOMETRY", 10.0f);
 		}
 

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -271,6 +271,12 @@ public:
 		case MAVLINK_MODE_UAVIONIX:
 			return "uAvionix";
 
+		case MAVLINK_MODE_PARACHUTE:
+			return "Parachute";
+
+		case MAVLINK_MODE_TRN:
+			return "TRN";
+
 		default:
 			return "Unknown";
 		}


### PR DESCRIPTION
Fixes these warnings:
```
INFO  [mavlink] mode: Unknown, data rate: 200000 B/s on /dev/ttyS1 @ 2000000B
WARN  [mavlink] stream RAW_PRESSURE not found
WARN  [mavlink] stream RAW_IMU not found
ERROR [mavlink] configure_streams_to_default() failed
```
