### PR TITLE
Mr altitude loss failure detection

### DIFF
--- a/Tools/aviant/open_lastest_sitl_ulog.sh
+++ b/Tools/aviant/open_lastest_sitl_ulog.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+LOGPATH="build/px4_sitl_default/rootfs/log"
+LOGFOLDER="$(ls -t1 $LOGPATH | head -n 1)"
+echo "LOGFOLDER is ${LOGFOLDER}"
+LOGFILE="$(ls -t1 ${LOGPATH}/${LOGFOLDER} | head -n 1)"
+
+echo "LOGFILE is ${LOGPATH}/${LOGFOLDER}/${LOGFILE}"
+xdg-open "${LOGPATH}/${LOGFOLDER}/${LOGFILE}"

--- a/msg/FailureDetectorStatus.msg
+++ b/msg/FailureDetectorStatus.msg
@@ -9,7 +9,11 @@ bool fd_arm_escs
 bool fd_battery
 bool fd_imbalanced_prop
 bool fd_motor
-bool fd_mpc_vz
+bool fd_mr_altloss
+
+# For troubleshooting and monitoring MR altloss failure detection
+float32 reference_z_position
+float32 maybe_mr_failure
 
 float32 imbalanced_prop_metric      # Metric of the imbalanced propeller check (low-passed)
 uint16 motor_failure_mask           # Bit-mask with motor indices, indicating critical motor failures

--- a/msg/FailureDetectorStatus.msg
+++ b/msg/FailureDetectorStatus.msg
@@ -10,10 +10,10 @@ bool fd_battery
 bool fd_imbalanced_prop
 bool fd_motor
 bool fd_mr_altloss
+bool fd_mr_falling
 
-# For troubleshooting and monitoring MR altloss failure detection
 float32 reference_z_position
-float32 maybe_mr_failure
+float32 lookahead_z_position
 
 float32 imbalanced_prop_metric      # Metric of the imbalanced propeller check (low-passed)
 uint16 motor_failure_mask           # Bit-mask with motor indices, indicating critical motor failures

--- a/msg/VehicleStatus.msg
+++ b/msg/VehicleStatus.msg
@@ -81,7 +81,7 @@ uint16 FAILURE_ARM_ESC = 16          # (1 << 4)
 uint16 FAILURE_BATTERY = 32          # (1 << 5)
 uint16 FAILURE_IMBALANCED_PROP = 64  # (1 << 6)
 uint16 FAILURE_MOTOR = 128           # (1 << 7)
-uint16 FAILURE_MPC_VZ = 256          # (1 << 8)
+uint16 FAILURE_MR_ALTLOSS = 256      # (1 << 8)
 
 uint8 hil_state
 uint8 HIL_STATE_OFF = 0

--- a/msg/VehicleStatus.msg
+++ b/msg/VehicleStatus.msg
@@ -82,6 +82,7 @@ uint16 FAILURE_BATTERY = 32          # (1 << 5)
 uint16 FAILURE_IMBALANCED_PROP = 64  # (1 << 6)
 uint16 FAILURE_MOTOR = 128           # (1 << 7)
 uint16 FAILURE_MR_ALTLOSS = 256      # (1 << 8)
+uint16 FAILURE_MR_FALLING = 512      # (1 << 9)
 
 uint8 hil_state
 uint8 HIL_STATE_OFF = 0

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1930,8 +1930,9 @@ void Commander::run()
 			fd_status.fd_imbalanced_prop = _failure_detector.getStatusFlags().imbalanced_prop;
 			fd_status.fd_motor = _failure_detector.getStatusFlags().motor;
 			fd_status.fd_mr_altloss = _failure_detector.getStatusFlags().mr_altloss;
+			fd_status.fd_mr_falling = _failure_detector.getStatusFlags().mr_falling;
 			fd_status.reference_z_position = _failure_detector.getReferenceZPosition();
-			fd_status.maybe_mr_failure = _failure_detector.getMaybeMRFailure();
+			fd_status.lookahead_z_position = _failure_detector.getLookaheadZPosition();
 			fd_status.imbalanced_prop_metric = _failure_detector.getImbalancedPropMetric();
 			fd_status.motor_failure_mask = _failure_detector.getMotorFailures();
 			fd_status.timestamp = hrt_absolute_time();

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1824,7 +1824,7 @@ void Commander::run()
 		dataLinkCheck();
 
 		// Check for failure detector status
-		if (_failure_detector.update(_vehicle_status, _vehicle_control_mode)) {
+		if (_failure_detector.update(_vehicle_status, _vehicle_control_mode, _vtol_vehicle_status)) {
 			_vehicle_status.failure_detector_status = _failure_detector.getStatus().value;
 			_status_changed = true;
 		}
@@ -1929,7 +1929,9 @@ void Commander::run()
 			fd_status.fd_battery = _failure_detector.getStatusFlags().battery;
 			fd_status.fd_imbalanced_prop = _failure_detector.getStatusFlags().imbalanced_prop;
 			fd_status.fd_motor = _failure_detector.getStatusFlags().motor;
-			fd_status.fd_mpc_vz = _failure_detector.getStatusFlags().mpc_vz;
+			fd_status.fd_mr_altloss = _failure_detector.getStatusFlags().mr_altloss;
+			fd_status.reference_z_position = _failure_detector.getReferenceZPosition();
+			fd_status.maybe_mr_failure = _failure_detector.getMaybeMRFailure();
 			fd_status.imbalanced_prop_metric = _failure_detector.getImbalancedPropMetric();
 			fd_status.motor_failure_mask = _failure_detector.getMotorFailures();
 			fd_status.timestamp = hrt_absolute_time();

--- a/src/modules/commander/HealthAndArmingChecks/checks/failureDetectorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/failureDetectorCheck.cpp
@@ -94,12 +94,11 @@ void FailureDetectorChecks::checkAndReport(const Context &context, Report &repor
 		}
 	}
 
-
 	if (context.status().failure_detector_status & vehicle_status_s::FAILURE_MR_ALTLOSS) {
 		/* EVENT
 		 * @description
 		 * <profile name="dev">
-		 * This check can be configured via <param>FD_MR_ALTLOSS</param> parameter.
+		 * This check can be configured via <param>FD_MR_ALOS*</param> parameters.
 		 * </profile>
 		 */
 		reporter.armingCheckFailure(NavModes::All, health_component_t::system, events::ID("check_failure_detector_mr_altloss"),
@@ -110,9 +109,24 @@ void FailureDetectorChecks::checkAndReport(const Context &context, Report &repor
 		}
 	}
 
+	if (context.status().failure_detector_status & vehicle_status_s::FAILURE_MR_FALLING) {
+		/* EVENT
+		 * @description
+		 * <profile name="dev">
+		 * This check can be configured via <param>FD_MR_FALL*</param> parameters.
+		 * </profile>
+		 */
+		reporter.armingCheckFailure(NavModes::All, health_component_t::system, events::ID("check_failure_detector_mr_falling"),
+					    events::Log::Critical, "Multirotor falling detected");
+
+		if (reporter.mavlink_log_pub()) {
+			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Multirotor falling detected");
+		}
+	}
+
 	reporter.failsafeFlags().fd_critical_failure = context.status().failure_detector_status &
 			(vehicle_status_s::FAILURE_ROLL | vehicle_status_s::FAILURE_PITCH | vehicle_status_s::FAILURE_ALT |
-			 vehicle_status_s::FAILURE_EXT | vehicle_status_s::FAILURE_MR_ALTLOSS);
+			 vehicle_status_s::FAILURE_EXT | vehicle_status_s::FAILURE_MR_ALTLOSS | vehicle_status_s::FAILURE_MR_FALLING);
 
 
 	reporter.failsafeFlags().fd_esc_arming_failure = context.status().failure_detector_status &

--- a/src/modules/commander/HealthAndArmingChecks/checks/failureDetectorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/failureDetectorCheck.cpp
@@ -95,24 +95,24 @@ void FailureDetectorChecks::checkAndReport(const Context &context, Report &repor
 	}
 
 
-	if (context.status().failure_detector_status & vehicle_status_s::FAILURE_MPC_VZ) {
+	if (context.status().failure_detector_status & vehicle_status_s::FAILURE_MR_ALTLOSS) {
 		/* EVENT
 		 * @description
 		 * <profile name="dev">
-		 * This check can be configured via <param>FD_MPC_VZ_THR</param> parameter.
+		 * This check can be configured via <param>FD_MR_ALTLOSS</param> parameter.
 		 * </profile>
 		 */
-		reporter.armingCheckFailure(NavModes::All, health_component_t::system, events::ID("check_failure_detector_mpc_vz"),
-					    events::Log::Critical, "Multirotor vertical rate failure detected");
+		reporter.armingCheckFailure(NavModes::All, health_component_t::system, events::ID("check_failure_detector_mr_altloss"),
+					    events::Log::Critical, "Multirotor altitude loss detected");
 
 		if (reporter.mavlink_log_pub()) {
-			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Multirotor vertical rate failure detected");
+			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Multirotor altitude loss detected");
 		}
 	}
 
 	reporter.failsafeFlags().fd_critical_failure = context.status().failure_detector_status &
 			(vehicle_status_s::FAILURE_ROLL | vehicle_status_s::FAILURE_PITCH | vehicle_status_s::FAILURE_ALT |
-			 vehicle_status_s::FAILURE_EXT | vehicle_status_s::FAILURE_MPC_VZ);
+			 vehicle_status_s::FAILURE_EXT | vehicle_status_s::FAILURE_MR_ALTLOSS);
 
 
 	reporter.failsafeFlags().fd_esc_arming_failure = context.status().failure_detector_status &

--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -39,6 +39,10 @@
 */
 
 #include "FailureDetector.hpp"
+#include "px4_platform_common/defines.h"
+#include "uORB/topics/vehicle_control_mode.h"
+#include "uORB/topics/vtol_vehicle_status.h"
+#include <float.h>
 
 using namespace time_literals;
 
@@ -164,18 +168,16 @@ FailureDetector::FailureDetector(ModuleParams *parent) :
 {
 }
 
-bool FailureDetector::update(const vehicle_status_s &vehicle_status, const vehicle_control_mode_s &vehicle_control_mode)
+bool FailureDetector::update(const vehicle_status_s &vehicle_status, const vehicle_control_mode_s &vehicle_control_mode,
+			     const vtol_vehicle_status_s &vtol_vehicle_status)
 {
 	_failure_injector.update();
 
 	failure_detector_status_u status_prev = _status;
 
-	if (vehicle_control_mode.flag_multicopter_position_control_enabled && _param_fd_mpc_vz_thr.get() > 0) {
-		updateMpcVzStatus();
-
-	} else {
-		_status.flags.mpc_vz = false;
-	}
+	// We check the running conditions for MR altitude loss failure (e.g. MR position control active)
+	// inside the function, since it needs to store state, and then it's more easily verified as correct
+	updateMRAltLossStatus(vtol_vehicle_status);
 
 	if (vehicle_control_mode.flag_control_attitude_enabled) {
 		updateAttitudeStatus(vehicle_status);
@@ -480,27 +482,96 @@ void FailureDetector::updateMotorStatus(const vehicle_status_s &vehicle_status, 
 	}
 }
 
-
-void FailureDetector::updateMpcVzStatus()
+void FailureDetector::updateMRAltLossStatus(const vtol_vehicle_status_s &vtol_vehicle_status)
 {
+	// We check strictly for multicopter, since
+	// During VTOL transition, we want the altitude loss failure mode to be quadchute.
+	// Then, this check should not run
+	if (vtol_vehicle_status.vehicle_vtol_state != vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC) {
+		_reference_z_position = NAN;
+		_status.flags.mr_altloss = false;
+		return;
+	}
+
 	vehicle_local_position_s position;
 	vehicle_local_position_setpoint_s position_sp;
 
 	if (_vehicle_local_position_sub.update(&position) &&
 	    _vehicle_local_position_setpoint_sub.copy(&position_sp)) {
 
-		const float max_z_velocity = _param_fd_mpc_vz_thr.get();
+		if (PX4_ISFINITE(position_sp.z) && position.z_valid) {
+			// For an explanation of the reference z position, see https://aviant.atlassian.net/wiki/x/EQBofQ
+			_reference_z_position = max(
+							position_sp.z,
+							PX4_ISFINITE(_reference_z_position) ? min(position.z, _reference_z_position) : position.z
+						);
 
-		const bool is_descending_too_fast = position.v_z_valid && position.vz > max_z_velocity;
-		const bool is_trying_to_climb = PX4_ISFINITE(position_sp.vz) && position_sp.vz < -FLT_EPSILON;
 
-		const bool mpc_vz_status = is_trying_to_climb && is_descending_too_fast;
+			const float z_error = _reference_z_position - position.z;
+			const float altitude_loss = -z_error;  // Flip the sign to make logic easier
 
-		hrt_abstime time_now = hrt_absolute_time();
+			// To safeguard against edgecases in the calculation of the reference altitude,
+			// we don't want to trigger the failure detector unless the aircraft is actually descending
+			// Maybe the reference altitude jumped up for some reason, and we are successfully tracking it
+			const bool is_descending_or_unknown = !position.v_z_valid || position.vz > _param_fd_mr_vz.get();
 
-		_mpc_vz_failure_hysteresis.set_hysteresis_time_from(false, (hrt_abstime)(1_s * _param_fd_mpc_vz_ttri.get()));
-		_mpc_vz_failure_hysteresis.set_state_and_update(mpc_vz_status, time_now);
+			// Also, we don't want to trigger based on altitude error if the vehicle is actively trying to descend.
+			// Maybe the reference altitude is lagging behind for some reason, which leads to artifially large altitude loss
+			const bool is_trying_to_descend = PX4_ISFINITE(position_sp.vz) && position_sp.vz > 0;
 
-		_status.flags.mpc_vz = _mpc_vz_failure_hysteresis.get_state();
+			if (
+				_param_fd_mr_altloss.get() > FLT_EPSILON
+				&& altitude_loss > _param_fd_mr_altloss.get()
+				&& is_descending_or_unknown
+				&& !is_trying_to_descend
+			) {
+				if (!_maybe_mr_failure) {
+					PX4_WARN("FailureDetector: Multirotor altitude loss detected!");
+				}
+
+				_maybe_mr_failure = true;
+
+			} else {
+				_maybe_mr_failure = false;
+			}
+
+		} else {
+			// Invalid altitude setpoint or state, we fall back to a velocity-based trigger
+
+			// It's important to reset the z position to NAN,
+			// so it initializes properly if we regain position estimate and setpoint
+			_reference_z_position = NAN;
+
+			const bool ignore_failure_because_close_to_ground = (
+						position.dist_bottom_valid
+						&& _param_fd_mr_fb_gnd_dst.get() > FLT_EPSILON
+						&& position.dist_bottom < _param_fd_mr_fb_gnd_dst.get()
+					);
+
+
+			// NOTE: we explicitly don't check the vz setpoint here,
+			// we want to trigger the failsafe even if we don't have a velocity setpoint
+			// e.g. if we experience motor failure while flying in stabilized mode
+			if (
+				position.v_z_valid
+				&& _param_fd_mr_fb_vz.get() > FLT_EPSILON  // NOTE: Fallback VZ, not the same as above
+				&& position.vz > _param_fd_mr_fb_vz.get()
+				&& !ignore_failure_because_close_to_ground
+			) {
+				if (!_maybe_mr_failure) {
+					PX4_WARN("FailureDetector: Large multirotor descent speed detected!");
+				}
+
+				_maybe_mr_failure = true;
+
+			} else {
+				_maybe_mr_failure = false;
+			}
+		}
 	}
+
+	const hrt_abstime time_now = hrt_absolute_time();
+	_mr_altitude_failure_hysteresis.set_hysteresis_time_from(false, (hrt_abstime)(1_s * _param_fd_mr_ttri.get()));
+	_mr_altitude_failure_hysteresis.set_state_and_update(_maybe_mr_failure, time_now);
+	_status.flags.mr_altloss = _mr_altitude_failure_hysteresis.get_state();
 }

--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -515,15 +515,10 @@ void FailureDetector::updateMRAltLossStatus(const vtol_vehicle_status_s &vtol_ve
 			// Maybe the reference altitude jumped up for some reason, and we are successfully tracking it
 			const bool is_descending_or_unknown = !position.v_z_valid || position.vz > _param_fd_mr_vz.get();
 
-			// Also, we don't want to trigger based on altitude error if the vehicle is actively trying to descend.
-			// Maybe the reference altitude is lagging behind for some reason, which leads to artifially large altitude loss
-			const bool is_trying_to_descend = PX4_ISFINITE(position_sp.vz) && position_sp.vz > 0;
-
 			if (
 				_param_fd_mr_altloss.get() > FLT_EPSILON
 				&& altitude_loss > _param_fd_mr_altloss.get()
 				&& is_descending_or_unknown
-				&& !is_trying_to_descend
 			) {
 				if (!_maybe_mr_failure) {
 					PX4_WARN("FailureDetector: Multirotor altitude loss detected!");

--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -41,6 +41,9 @@
 #include "FailureDetector.hpp"
 #include "px4_platform_common/defines.h"
 #include "uORB/topics/vehicle_control_mode.h"
+#include "uORB/topics/vehicle_local_position.h"
+#include "uORB/topics/vehicle_local_position_setpoint.h"
+#include "uORB/topics/vehicle_status.h"
 #include "uORB/topics/vtol_vehicle_status.h"
 #include <float.h>
 
@@ -175,9 +178,30 @@ bool FailureDetector::update(const vehicle_status_s &vehicle_status, const vehic
 
 	failure_detector_status_u status_prev = _status;
 
-	// We check the running conditions for MR altitude loss failure (e.g. MR position control active)
-	// inside the function, since it needs to store state, and then it's more easily verified as correct
-	updateMRAltLossStatus(vtol_vehicle_status);
+	// We check strictly for multicopter, since
+	// During VTOL transition, we want the altitude loss failure mode to be quadchute.
+	// Then, this check should not run
+	if (vtol_vehicle_status.vehicle_vtol_state == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC) {
+
+		vehicle_local_position_s position;
+		vehicle_local_position_setpoint_s position_sp;
+
+		if (_vehicle_local_position_sub.update(&position)) {
+			updateMRFallingStatus(position);
+
+			if (_vehicle_local_position_setpoint_sub.copy(&position_sp)) {
+				updateMRAltLossStatus(position, position_sp);
+			}
+		}
+
+	} else {
+		// it's important to reset the reference and lookahead positions,
+		// so they can initialize properly the next time we enter multirotor mode
+		_reference_z_position = NAN;
+		_lookahead_z_position = NAN;
+		_status.flags.mr_altloss = false;
+		_status.flags.mr_falling = false;
+	}
 
 	if (vehicle_control_mode.flag_control_attitude_enabled) {
 		updateAttitudeStatus(vehicle_status);
@@ -482,91 +506,51 @@ void FailureDetector::updateMotorStatus(const vehicle_status_s &vehicle_status, 
 	}
 }
 
-void FailureDetector::updateMRAltLossStatus(const vtol_vehicle_status_s &vtol_vehicle_status)
+void FailureDetector::updateMRAltLossStatus(const vehicle_local_position_s &position,
+		const vehicle_local_position_setpoint_s &position_sp)
 {
-	// We check strictly for multicopter, since
-	// During VTOL transition, we want the altitude loss failure mode to be quadchute.
-	// Then, this check should not run
-	if (vtol_vehicle_status.vehicle_vtol_state != vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC) {
-		_reference_z_position = NAN;
+	if (!PX4_ISFINITE(position_sp.z) || !position.z_valid) {
 		_status.flags.mr_altloss = false;
+		_reference_z_position = NAN;
+		_lookahead_z_position = NAN;
 		return;
 	}
 
-	vehicle_local_position_s position;
-	vehicle_local_position_setpoint_s position_sp;
-
-	if (_vehicle_local_position_sub.update(&position) &&
-	    _vehicle_local_position_setpoint_sub.copy(&position_sp)) {
-
-		if (PX4_ISFINITE(position_sp.z) && position.z_valid) {
-			// For an explanation of the reference z position, see https://aviant.atlassian.net/wiki/x/EQBofQ
-			_reference_z_position = max(
-							position_sp.z,
-							PX4_ISFINITE(_reference_z_position) ? min(position.z, _reference_z_position) : position.z
-						);
+	// For an explanation of the reference z position, see https://aviant.atlassian.net/wiki/x/EQBofQ
+	_reference_z_position = max(
+					position_sp.z,
+					PX4_ISFINITE(_reference_z_position) ? min(position.z, _reference_z_position) : position.z
+				);
 
 
-			const float z_error = _reference_z_position - position.z;
-			const float altitude_loss = -z_error;  // Flip the sign to make logic easier
+	// We don't really need to store the lookahead z as a member variable,
+	// but we choose to do it so we can get it to commander,
+	// which publishes failure_detector_status, so we can inspect it in the ulog
+	_lookahead_z_position = position.v_z_valid ? position.z + position.vz * _param_fd_mr_alos_la_t.get() : position.z;
 
-			// To safeguard against edgecases in the calculation of the reference altitude,
-			// we don't want to trigger the failure detector unless the aircraft is actually descending
-			// Maybe the reference altitude jumped up for some reason, and we are successfully tracking it
-			const bool is_descending_or_unknown = !position.v_z_valid || position.vz > _param_fd_mr_vz.get();
+	const float lookahead_z_error = _reference_z_position - _lookahead_z_position;
+	const float lookahead_altitude_loss = -lookahead_z_error;  // Flip the sign to make logic easier
 
-			if (
-				_param_fd_mr_altloss.get() > FLT_EPSILON
-				&& altitude_loss > _param_fd_mr_altloss.get()
-				&& is_descending_or_unknown
-			) {
-				if (!_maybe_mr_failure) {
-					PX4_WARN("FailureDetector: Multirotor altitude loss detected!");
-				}
+	_status.flags.mr_altloss = (
+					   _param_fd_mr_alos_lim.get() > FLT_EPSILON
+					   && lookahead_altitude_loss > _param_fd_mr_alos_lim.get()
+				   );
+}
 
-				_maybe_mr_failure = true;
-
-			} else {
-				_maybe_mr_failure = false;
-			}
-
-		} else {
-			// Invalid altitude setpoint or state, we fall back to a velocity-based trigger
-
-			// It's important to reset the z position to NAN,
-			// so it initializes properly if we regain position estimate and setpoint
-			_reference_z_position = NAN;
-
-			const bool ignore_failure_because_close_to_ground = (
-						position.dist_bottom_valid
-						&& _param_fd_mr_fb_gnd_dst.get() > FLT_EPSILON
-						&& position.dist_bottom < _param_fd_mr_fb_gnd_dst.get()
-					);
-
-
-			// NOTE: we explicitly don't check the vz setpoint here,
-			// we want to trigger the failsafe even if we don't have a velocity setpoint
-			// e.g. if we experience motor failure while flying in stabilized mode
-			if (
-				position.v_z_valid
-				&& _param_fd_mr_fb_vz.get() > FLT_EPSILON  // NOTE: Fallback VZ, not the same as above
-				&& position.vz > _param_fd_mr_fb_vz.get()
-				&& !ignore_failure_because_close_to_ground
-			) {
-				if (!_maybe_mr_failure) {
-					PX4_WARN("FailureDetector: Large multirotor descent speed detected!");
-				}
-
-				_maybe_mr_failure = true;
-
-			} else {
-				_maybe_mr_failure = false;
-			}
-		}
+void FailureDetector::updateMRFallingStatus(const vehicle_local_position_s &position)
+{
+	if (!position.v_z_valid) {
+		_status.flags.mr_falling = false;
+		return;
 	}
 
+	const bool failure = (
+				     _param_fd_mr_fall_vz.get() > FLT_EPSILON
+				     && position.vz > _param_fd_mr_fall_vz.get()
+			     );
+
 	const hrt_abstime time_now = hrt_absolute_time();
-	_mr_altitude_failure_hysteresis.set_hysteresis_time_from(false, (hrt_abstime)(1_s * _param_fd_mr_ttri.get()));
-	_mr_altitude_failure_hysteresis.set_state_and_update(_maybe_mr_failure, time_now);
-	_status.flags.mr_altloss = _mr_altitude_failure_hysteresis.get_state();
+	_mr_falling_failure_hysteresis.set_hysteresis_time_from(false, (hrt_abstime)(1_s * _param_fd_mr_fall_ttri.get()));
+	_mr_falling_failure_hysteresis.set_state_and_update(failure, time_now);
+	_status.flags.mr_falling = _mr_falling_failure_hysteresis.get_state();
 }

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -77,7 +77,7 @@ union failure_detector_status_u {
 		uint16_t battery : 1;
 		uint16_t imbalanced_prop : 1;
 		uint16_t motor : 1;
-		uint16_t mpc_vz : 1;
+		uint16_t mr_altloss : 1;
 	} flags;
 	uint16_t value {0};
 };
@@ -104,27 +104,33 @@ public:
 	FailureDetector(ModuleParams *parent);
 	~FailureDetector() = default;
 
-	bool update(const vehicle_status_s &vehicle_status, const vehicle_control_mode_s &vehicle_control_mode);
+	bool update(const vehicle_status_s &vehicle_status, const vehicle_control_mode_s &vehicle_control_mode,
+		    const vtol_vehicle_status_s &vtol_vehicle_status);
 	const failure_detector_status_u &getStatus() const { return _status; }
 	const decltype(failure_detector_status_u::flags) &getStatusFlags() const { return _status.flags; }
 	float getImbalancedPropMetric() const { return _imbalanced_prop_lpf.getState(); }
 	uint16_t getMotorFailures() const { return _motor_failure_esc_timed_out_mask | _motor_failure_esc_under_current_mask; }
+	float getReferenceZPosition() const {return _reference_z_position; }
+	float getMaybeMRFailure() const {return _maybe_mr_failure; }
 
 private:
 	void updateAttitudeStatus(const vehicle_status_s &vehicle_status);
 	void updateExternalAtsStatus();
 	void updateEscsStatus(const vehicle_status_s &vehicle_status, const esc_status_s &esc_status);
 	void updateMotorStatus(const vehicle_status_s &vehicle_status, const esc_status_s &esc_status);
-	void updateMpcVzStatus();
+	void updateMRAltLossStatus(const vtol_vehicle_status_s &vtol_vehicle_status);
 	void updateImbalancedPropStatus();
 
 	failure_detector_status_u _status{};
+
+	float _reference_z_position{NAN};
+	bool _maybe_mr_failure{false};  // used for warning and logging before hysteresis
 
 	systemlib::Hysteresis _roll_failure_hysteresis{false};
 	systemlib::Hysteresis _pitch_failure_hysteresis{false};
 	systemlib::Hysteresis _ext_ats_failure_hysteresis{false};
 	systemlib::Hysteresis _esc_failure_hysteresis{false};
-	systemlib::Hysteresis _mpc_vz_failure_hysteresis{false};
+	systemlib::Hysteresis _mr_altitude_failure_hysteresis{false};
 
 	static constexpr float _imbalanced_prop_lpf_time_constant{5.f};
 	AlphaFilter<float> _imbalanced_prop_lpf{};
@@ -164,7 +170,10 @@ private:
 		(ParamFloat<px4::params::FD_ACT_MOT_THR>) _param_fd_motor_throttle_thres,
 		(ParamFloat<px4::params::FD_ACT_MOT_C2T>) _param_fd_motor_current2throttle_thres,
 		(ParamInt<px4::params::FD_ACT_MOT_TOUT>) _param_fd_motor_time_thres,
-		(ParamInt<px4::params::FD_MPC_VZ_THR>) _param_fd_mpc_vz_thr,
-		(ParamFloat<px4::params::FD_MPC_VZ_TTRI>) _param_fd_mpc_vz_ttri
+		(ParamFloat<px4::params::FD_MR_ALTLOSS>) _param_fd_mr_altloss,
+		(ParamFloat<px4::params::FD_MR_VZ>) _param_fd_mr_vz,
+		(ParamFloat<px4::params::FD_MR_FB_VZ>) _param_fd_mr_fb_vz,
+		(ParamFloat<px4::params::FD_MR_FB_GND_DST>) _param_fd_mr_fb_gnd_dst,
+		(ParamFloat<px4::params::FD_MR_TTRI>) _param_fd_mr_ttri
 	)
 };

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -78,6 +78,7 @@ union failure_detector_status_u {
 		uint16_t imbalanced_prop : 1;
 		uint16_t motor : 1;
 		uint16_t mr_altloss : 1;
+		uint16_t mr_falling : 1;
 	} flags;
 	uint16_t value {0};
 };
@@ -111,26 +112,28 @@ public:
 	float getImbalancedPropMetric() const { return _imbalanced_prop_lpf.getState(); }
 	uint16_t getMotorFailures() const { return _motor_failure_esc_timed_out_mask | _motor_failure_esc_under_current_mask; }
 	float getReferenceZPosition() const {return _reference_z_position; }
-	float getMaybeMRFailure() const {return _maybe_mr_failure; }
+	float getLookaheadZPosition() const {return _lookahead_z_position; }
 
 private:
 	void updateAttitudeStatus(const vehicle_status_s &vehicle_status);
 	void updateExternalAtsStatus();
 	void updateEscsStatus(const vehicle_status_s &vehicle_status, const esc_status_s &esc_status);
 	void updateMotorStatus(const vehicle_status_s &vehicle_status, const esc_status_s &esc_status);
-	void updateMRAltLossStatus(const vtol_vehicle_status_s &vtol_vehicle_status);
+	void updateMRAltLossStatus(const vehicle_local_position_s &position,
+				   const vehicle_local_position_setpoint_s &position_sp);
+	void updateMRFallingStatus(const vehicle_local_position_s &position);
 	void updateImbalancedPropStatus();
 
 	failure_detector_status_u _status{};
 
 	float _reference_z_position{NAN};
-	bool _maybe_mr_failure{false};  // used for warning and logging before hysteresis
+	float _lookahead_z_position{NAN};
 
 	systemlib::Hysteresis _roll_failure_hysteresis{false};
 	systemlib::Hysteresis _pitch_failure_hysteresis{false};
 	systemlib::Hysteresis _ext_ats_failure_hysteresis{false};
 	systemlib::Hysteresis _esc_failure_hysteresis{false};
-	systemlib::Hysteresis _mr_altitude_failure_hysteresis{false};
+	systemlib::Hysteresis _mr_falling_failure_hysteresis{false};
 
 	static constexpr float _imbalanced_prop_lpf_time_constant{5.f};
 	AlphaFilter<float> _imbalanced_prop_lpf{};
@@ -170,10 +173,9 @@ private:
 		(ParamFloat<px4::params::FD_ACT_MOT_THR>) _param_fd_motor_throttle_thres,
 		(ParamFloat<px4::params::FD_ACT_MOT_C2T>) _param_fd_motor_current2throttle_thres,
 		(ParamInt<px4::params::FD_ACT_MOT_TOUT>) _param_fd_motor_time_thres,
-		(ParamFloat<px4::params::FD_MR_ALTLOSS>) _param_fd_mr_altloss,
-		(ParamFloat<px4::params::FD_MR_VZ>) _param_fd_mr_vz,
-		(ParamFloat<px4::params::FD_MR_FB_VZ>) _param_fd_mr_fb_vz,
-		(ParamFloat<px4::params::FD_MR_FB_GND_DST>) _param_fd_mr_fb_gnd_dst,
-		(ParamFloat<px4::params::FD_MR_TTRI>) _param_fd_mr_ttri
+		(ParamFloat<px4::params::FD_MR_ALOS_LIM>) _param_fd_mr_alos_lim,
+		(ParamFloat<px4::params::FD_MR_ALOS_LA_T>) _param_fd_mr_alos_la_t,
+		(ParamFloat<px4::params::FD_MR_FALL_VZ>) _param_fd_mr_fall_vz,
+		(ParamFloat<px4::params::FD_MR_FALL_TTRI>) _param_fd_mr_fall_ttri
 	)
 };

--- a/src/modules/commander/failure_detector/failure_detector_params.c
+++ b/src/modules/commander/failure_detector/failure_detector_params.c
@@ -214,74 +214,22 @@ PARAM_DEFINE_FLOAT(FD_ACT_MOT_C2T, 2.0f);
 PARAM_DEFINE_INT32(FD_ACT_MOT_TOUT, 100);
 
 /**
- * Multicopter altitude fail threshold
+ * Multicopter altitude loss trigger threshold
  *
- * Maximum multirotor altitude loss before FailureDetector triggers
- * Will only be triggered if the setpoint is negative (ascending).
- * and the aircraft is descending faster than FD_MR_VZ
+ * Maximum multirotor altitude loss before FailureDetector triggers.
+ * Note: Uses lookahead with FD_MR_AL_LA_T
  * Set to 0 to disable.
  *
  * @min 0
  * @max 20
- * @increment 1
+ * @decimal 2
  * @reboot_required true
  * @group Failure Detector
  */
-PARAM_DEFINE_FLOAT(FD_MR_ALTLOSS, 0);
+PARAM_DEFINE_FLOAT(FD_MR_ALOS_LIM, 0);
 
 /**
- * Multicopter vertical rate fail threshold
- *
- * Additional sanity check on the altitude loss failure detector
- * This parameter determines the vertical rate needed to consider a failure
- *
- * @min 0
- * @max 2.5
- * @increment 0.1
- * @reboot_required true
- * @group Failure Detector
- */
-PARAM_DEFINE_FLOAT(FD_MR_VZ, 0);
-
-/**
- * Multicopter vertical rate fallback fail threshold
- *
- * If there is no valid position setpoint, we have to detect failures based on velocity.
- * Then, we need a higher threshold in order to avoid false positives.
- * Set to 0 or negative to disable.
- *
- * @min 0
- * @max 20
- * @increment 1
- * @reboot_required true
- * @group Failure Detector
- */
-
-PARAM_DEFINE_FLOAT(FD_MR_FB_VZ, 0);
-
-/**
- * Multicopter failure detection ground distance
- *
- * Minimum distance AGL (vehicle_local_position.dist_bottom) where the backup (speed-based)
- * multirotor failure detector will trigger.
- * The intention is to avoid parachute deployments close to the ground, since we won't
- * have time to fully deploy.
- * Set to 0 or negative to disable
- * NOTE: This has no effect on the altitude-based trigger
- *
- * @min 0
- * @max 20
- * @increment 1
- * @reboot_required true
- * @group Failure Detector
- */
-PARAM_DEFINE_FLOAT(FD_MR_FB_GND_DST, 0);
-
-/**
- * Multicopter failure detection trigger time
- *
- * This applies to both the primary (altitude-based) and fallback (velocity-based)
- * multicopter failure detectors
+ * Multicopter altitude loss lookahead time
  *
  * @unit s
  * @min 0.02
@@ -291,4 +239,35 @@ PARAM_DEFINE_FLOAT(FD_MR_FB_GND_DST, 0);
  * @group Failure Detector
  *
  */
-PARAM_DEFINE_FLOAT(FD_MR_TTRI, 0.3);
+PARAM_DEFINE_FLOAT(FD_MR_ALOS_LA_T, 1.0);
+
+/**
+ * Multicopter fall trigger velocity threshold
+ *
+ * This parameter determines the vertical rate needed to consider a failure
+ * in the fall trigger multirotor failure detector
+ * NOTE: The fall trigger has no altitude loss requirement
+ * Set to 0 to disable
+ *
+ * @min 0
+ * @max 10
+ * @decimal 2
+ * @reboot_required true
+ * @group Failure Detector
+ */
+PARAM_DEFINE_FLOAT(FD_MR_FALL_VZ, 0);
+
+/**
+ * Multicopter fall detector trigger time
+ *
+ * The consecutive time the conditions must be true to trigger the failure detector
+ *
+ * @unit s
+ * @min 0.02
+ * @max 5
+ * @decimal 2
+ * @reboot_required true
+ * @group Failure Detector
+ *
+ */
+PARAM_DEFINE_FLOAT(FD_MR_FALL_TTRI, 0.3);

--- a/src/modules/commander/failure_detector/failure_detector_params.c
+++ b/src/modules/commander/failure_detector/failure_detector_params.c
@@ -214,30 +214,81 @@ PARAM_DEFINE_FLOAT(FD_ACT_MOT_C2T, 2.0f);
 PARAM_DEFINE_INT32(FD_ACT_MOT_TOUT, 100);
 
 /**
- * Multicopter altitude rate fail threshold
+ * Multicopter altitude fail threshold
  *
- * Maximum downwards vertical velocity before FailureDetector triggers the MR vertical_rate_failure flag.
+ * Maximum multirotor altitude loss before FailureDetector triggers
  * Will only be triggered if the setpoint is negative (ascending).
+ * and the aircraft is descending faster than FD_MR_VZ
  * Set to 0 to disable.
  *
  * @min 0
  * @max 20
  * @increment 1
+ * @reboot_required true
  * @group Failure Detector
  */
-PARAM_DEFINE_INT32(FD_MPC_VZ_THR, 0);
+PARAM_DEFINE_FLOAT(FD_MR_ALTLOSS, 0);
 
 /**
- * Multicopter altitude rate fail trigger time
+ * Multicopter vertical rate fail threshold
  *
- * Seconds (decimal) that MR vertical rate has to exceed FD_MPC_VZ_THR before being considered as a failure.
+ * Additional sanity check on the altitude loss failure detector
+ * This parameter determines the vertical rate needed to consider a failure
+ *
+ * @min 0
+ * @max 2.5
+ * @increment 0.1
+ * @reboot_required true
+ * @group Failure Detector
+ */
+PARAM_DEFINE_FLOAT(FD_MR_VZ, 0);
+
+/**
+ * Multicopter vertical rate fallback fail threshold
+ *
+ * If there is no valid position setpoint, we have to detect failures based on velocity.
+ * Then, we need a higher threshold in order to avoid false positives.
+ * Set to 0 or negative to disable.
+ *
+ * @min 0
+ * @max 20
+ * @increment 1
+ * @reboot_required true
+ * @group Failure Detector
+ */
+
+PARAM_DEFINE_FLOAT(FD_MR_FB_VZ, 0);
+
+/**
+ * Multicopter failure detection ground distance
+ *
+ * Minimum distance AGL (vehicle_local_position.dist_bottom) where the backup (speed-based)
+ * multirotor failure detector will trigger.
+ * The intention is to avoid parachute deployments close to the ground, since we won't
+ * have time to fully deploy.
+ * Set to 0 or negative to disable
+ * NOTE: This has no effect on the altitude-based trigger
+ *
+ * @min 0
+ * @max 20
+ * @increment 1
+ * @reboot_required true
+ * @group Failure Detector
+ */
+PARAM_DEFINE_FLOAT(FD_MR_FB_GND_DST, 0);
+
+/**
+ * Multicopter failure detection trigger time
+ *
+ * This applies to both the primary (altitude-based) and fallback (velocity-based)
+ * multicopter failure detectors
  *
  * @unit s
  * @min 0.02
  * @max 5
  * @decimal 2
- *
+ * @reboot_required true
  * @group Failure Detector
+ *
  */
-PARAM_DEFINE_FLOAT(FD_MPC_VZ_TTRI, 0.3);
-
+PARAM_DEFINE_FLOAT(FD_MR_TTRI, 0.3);


### PR DESCRIPTION
Implementation of the proposed fix for https://aviant.atlassian.net/wiki/spaces/TECHNICAL/pages/2103967761
We probably don't want to merge into `aviant/1.15` flight tests before flight tests.

Also included a convenience script which speeds up sitl testing.

Sim testing:
- [x] Altitude-based true positive (set MPC_THR_MAX=0.4)
- [x] Nan-position-sp true positive (set MPC_THR_MAX=0.1)
- [x] Basic false positive checks (rapid ascent/descent)
