### PR TITLE
Fix fixed-wing mission transition and loiter logic edge cases

### DIFF
--- a/msg/MissionResult.msg
+++ b/msg/MissionResult.msg
@@ -6,6 +6,7 @@ uint32 home_position_counter  	# Counter of the home position for which the resu
 
 int32 seq_reached		# Sequence of the mission item which has been reached, default -1
 uint16 seq_current		# Sequence of the current mission item
+uint16 seq_previous		# Sequence of the previous mission item
 uint16 seq_total		# Total number of mission items
 
 bool valid			# true if mission is valid

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -1022,11 +1022,9 @@ FixedwingPositionControl::handle_setpoint_type(const position_setpoint_s &pos_sp
 					   &dist_xy, &dist_z);
 
 		// Achieve position setpoint altitude via loiter when laterally close to WP.
-		// Detect if system has switchted into a Loiter before (check _position_sp_type), and in that
-		// case remove the dist_xy check (not switch out of Loiter until altitude is reached).
 		if ((!_vehicle_status.in_transition_mode) && (dist >= 0.f)
 		    && (dist_z > _param_nav_fw_alt_rad.get())
-		    && (dist_xy < acc_rad || _position_sp_type == position_setpoint_s::SETPOINT_TYPE_LOITER)) {
+		    && (dist_xy < acc_rad)) {
 
 			// SETPOINT_TYPE_POSITION -> SETPOINT_TYPE_LOITER
 			position_sp_type = position_setpoint_s::SETPOINT_TYPE_LOITER;

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -301,7 +301,8 @@ void Mission::handleTakeoff(WorkItemType &new_work_item_type, mission_item_s nex
 	/* do climb before going to setpoint if needed and not already executing climb */
 	/* in fixed-wing this whole block will be ignored and a takeoff item is always propagated */
 	if (PX4_ISFINITE(_mission_init_climb_altitude_amsl) &&
-	    _work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) {
+	    (_work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) &&
+	    (_vehicle_status_sub.get().vehicle_type != vehicle_status_s::VEHICLE_TYPE_FIXED_WING)) {
 
 		new_work_item_type = WorkItemType::WORK_ITEM_TYPE_CLIMB;
 

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -526,7 +526,14 @@ void
 MissionBase::set_mission_result()
 {
 	_navigator->get_mission_result()->finished = false;
+
+	uint16_t old_seq_current = _navigator->get_mission_result()->seq_current;
 	_navigator->get_mission_result()->seq_current = _mission.current_seq > 0 ? _mission.current_seq : 0;
+
+	if (_navigator->get_mission_result()->seq_current != old_seq_current) {
+
+		_navigator->get_mission_result()->seq_previous = old_seq_current;
+	}
 
 	_navigator->set_mission_result_updated();
 }

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -376,6 +376,7 @@ private:
 
 	bool _is_capturing_images{false}; // keep track if we need to stop capturing images
 
+	position_setpoint_s _last_valid_previous_setpoint {};
 
 	// update subscriptions
 	void params_update();

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -915,6 +915,27 @@ void Navigator::run()
 		}
 
 		if (_pos_sp_triplet_updated) {
+
+			if (!_pos_sp_triplet.previous.valid &&
+			    (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_POSITION)) {
+
+				bool is_previous_setpoint = (_mission_result.seq_current == _mission_result.seq_previous + 1);
+
+				if (is_previous_setpoint &&
+				    _last_valid_previous_setpoint.valid &&
+				    (_vstatus.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION)) {
+					_pos_sp_triplet.previous = _last_valid_previous_setpoint;
+
+				} else {
+					_pos_sp_triplet.previous.timestamp = hrt_absolute_time();
+					_pos_sp_triplet.previous.valid = true;
+					_pos_sp_triplet.previous.type = position_setpoint_s::SETPOINT_TYPE_POSITION;
+					_pos_sp_triplet.previous.alt = get_global_position()->alt;
+					_pos_sp_triplet.previous.lon = get_global_position()->lon;
+					_pos_sp_triplet.previous.lat = get_global_position()->lat;
+				}
+			}
+
 			publish_position_setpoint_triplet();
 		}
 
@@ -1169,6 +1190,10 @@ float Navigator::get_altitude_acceptance_radius()
 
 void Navigator::reset_triplets()
 {
+	if (_pos_sp_triplet.previous.valid) {
+		_last_valid_previous_setpoint = _pos_sp_triplet.previous;
+	}
+
 	reset_position_setpoint(_pos_sp_triplet.previous);
 	reset_position_setpoint(_pos_sp_triplet.current);
 	reset_position_setpoint(_pos_sp_triplet.next);


### PR DESCRIPTION
### Bugs description:

#### 1) Invalid previous waypoint after mission jump breaks path continuity 
During a mission, when a new waypoint is selected (jumped to) via QGroundControl while the vehicle is already executing a mission, and the target waypoint has a different altitude than the current position, the vehicle will perform overly abrupt ascending or descending transitions.

Image show expected path vs. bug path when jump on waypoints is activated for two different cases: 
<img width="1659" height="869" alt="image" src="https://github.com/user-attachments/assets/3dc7d108-e423-421a-bc8c-ef33a9a61d09" />

#### 2) Fixed-wing takeoff climb incorrectly triggered during mission execution

During mission execution, the system could incorrectly trigger a takeoff climb (WORK_ITEM_TYPE_CLIMB) even when the vehicle was already airborne and navigating between waypoints.

This occurred because the climb logic was applied based only on the work item type being DEFAULT, without considering vehicle type.

#### 3) Fixed-wing loiter logic ignores altitude convergence requirement

The fixed-wing position controller could prematurely remain in LOITER mode during waypoint approach, even when altitude convergence was still required.

The previous implementation included an additional condition allowing LOITER behavior to persist once entered, based on prior state (_position_sp_type == LOITER). This caused the controller to ignore lateral distance checks and remain in LOITER longer than intended.

### Solutions

#### Bug 1) 
This change ensures that, if a previous valid waypoint exists and was part of the sequence, it will be used, otherwise, the vehicle's current global position (latitude, longitude, altitude) will be used.

This provides a safe and physically consistent fallback reference for the position controller, allowing it to reconstruct a valid trajectory segment and restore smooth transitions even after a mission jump or similar state reset.

#### Bug 2) 
Add vehicle type check to exclude fixed-wing from takeoff climb logic, ensuring WORK_ITEM_TYPE_CLIMB is only triggered for non-fixed-wing vehicles during mission execution.

#### Bug 3) 
Remove persistence of LOITER based on previous state and only allow LOITER entry when current lateral distance condition is met. This ensures loiter is strictly controlled by real-time geometry (distance checks), not previous setpoint type.
