### PR TITLE
Configurable position estimation groups

### DIFF
--- a/msg/EstimatorStatus.msg
+++ b/msg/EstimatorStatus.msg
@@ -135,6 +135,10 @@ uint8 POS_EST_FLAG_VISION_FUSION    = 32  # Fuse EV and optical flow
 uint8 POS_EST_FLAG_FAKE_POSITION    = 64  # Allow fake position fusion
 uint8 POS_EST_FLAG_SELECTABLE       = 128 # EKF can be selected by EKF2Selector
 
+uint8 pos_est_group
+uint8 POS_EST_GROUP_MAIN   = 0
+uint8 POS_EST_GROUP_BACKUP = 1
+
 # legacy local position estimator (LPE) flags
 uint8 health_flags		# Bitmask to indicate sensor health states (vel, pos, hgt)
 uint8 timeout_flags		# Bitmask to indicate timeout flags (vel, pos, hgt)

--- a/msg/EstimatorStatus.msg
+++ b/msg/EstimatorStatus.msg
@@ -124,6 +124,17 @@ uint32 gyro_device_id
 uint32 baro_device_id
 uint32 mag_device_id
 
+# Position estimation flags (bitmask)
+uint8 pos_est_flags
+uint8 POS_EST_FLAG_GNSS_INIT        = 1   # Fuse first GNSS measurement (before global origin valid)
+uint8 POS_EST_FLAG_GNSS_DISARMED    = 2   # Fuse GNSS while disarmed (after origin valid)
+uint8 POS_EST_FLAG_GNSS_ARMED       = 4   # Fuse GNSS while armed
+uint8 POS_EST_FLAG_EXT_GPOS_RESETS  = 8   # Reset to external position when dead reckoning
+uint8 POS_EST_FLAG_AUX_GPOS_FUSION  = 16  # Fuse auxiliary global position
+uint8 POS_EST_FLAG_VISION_FUSION    = 32  # Fuse EV and optical flow
+uint8 POS_EST_FLAG_FAKE_POSITION    = 64  # Allow fake position fusion
+uint8 POS_EST_FLAG_SELECTABLE       = 128 # EKF can be selected by EKF2Selector
+
 # legacy local position estimator (LPE) flags
 uint8 health_flags		# Bitmask to indicate sensor health states (vel, pos, hgt)
 uint8 timeout_flags		# Bitmask to indicate timeout flags (vel, pos, hgt)

--- a/src/modules/ekf2/EKF/aux_global_position.cpp
+++ b/src/modules/ekf2/EKF/aux_global_position.cpp
@@ -39,6 +39,9 @@
 
 void AuxGlobalPosition::update(Ekf &ekf, const estimator::imuSample &imu_delayed)
 {
+	if (!_enabled) {
+		return;
+	}
 
 #if defined(MODULE_NAME)
 

--- a/src/modules/ekf2/EKF/aux_global_position.hpp
+++ b/src/modules/ekf2/EKF/aux_global_position.hpp
@@ -69,12 +69,15 @@ public:
 
 	void update(Ekf &ekf, const estimator::imuSample &imu_delayed);
 
+	void setEnabled(bool enabled) { _enabled = enabled; }
+
 	void updateParameters()
 	{
 		updateParams();
 	}
 
 private:
+	bool _enabled{true};
 	bool isTimedOut(uint64_t last_sensor_timestamp, uint64_t time_delayed_us, uint64_t timeout_period) const
 	{
 		return (last_sensor_timestamp == 0) || (last_sensor_timestamp + timeout_period < time_delayed_us);

--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -334,6 +334,7 @@ void Ekf::resetGlobalPosToExternalObservation(double lat_deg, double lon_deg, fl
 {
 
 	if (!_pos_ref.isInitialized()) {
+		ECL_WARN("EXTPOS: pos_ref not initialized, cannot reset");
 		return;
 	}
 

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -87,6 +87,10 @@ public:
 
 	void print_status();
 
+#if defined(CONFIG_EKF2_AUX_GLOBAL_POSITION) && defined(MODULE_NAME)
+	void setAuxGlobalPositionEnabled(bool enabled) { _aux_global_position.setEnabled(enabled); }
+#endif
+
 	// should be called every time new data is pushed into the filter
 	bool update();
 

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -87,6 +87,8 @@ public:
 
 	void print_status();
 
+	void setFakePositionEnabled(bool enabled) { _fake_pos_enabled = enabled; }
+
 #if defined(CONFIG_EKF2_AUX_GLOBAL_POSITION) && defined(MODULE_NAME)
 	void setAuxGlobalPositionEnabled(bool enabled) { _aux_global_position.setEnabled(enabled); }
 #endif
@@ -636,6 +638,7 @@ private:
 	estimator_aid_source1d_s _aid_src_sideslip{};
 #endif // CONFIG_EKF2_SIDESLIP
 
+	bool _fake_pos_enabled{true};
 	estimator_aid_source2d_s _aid_src_fake_pos{};
 	estimator_aid_source1d_s _aid_src_fake_hgt{};
 

--- a/src/modules/ekf2/EKF/fake_pos_control.cpp
+++ b/src/modules/ekf2/EKF/fake_pos_control.cpp
@@ -42,6 +42,11 @@ void Ekf::controlFakePosFusion()
 {
 	auto &aid_src = _aid_src_fake_pos;
 
+	if (!_fake_pos_enabled) {
+		stopFakePosFusion();
+		return;
+	}
+
 	// If we aren't doing any aiding, fake position measurements at the last known position to constrain drift
 	// During initial tilt alignment, fake position is used to perform a "quasi-stationary" leveling of the EKF
 	const bool fake_pos_data_ready = !isHorizontalAidingActive()

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -235,8 +235,16 @@ EKF2::~EKF2()
 }
 
 #if defined(CONFIG_EKF2_MULTI_INSTANCE)
-bool EKF2::multi_init(int imu, int mag)
+bool EKF2::multi_init(int imu, int mag, uint8_t pos_est_flags)
 {
+	_pos_est_flags = pos_est_flags;
+
+	_ekf.setFakePositionEnabled((_pos_est_flags & estimator_status_s::POS_EST_FLAG_FAKE_POSITION) != 0);
+
+#if defined(CONFIG_EKF2_AUX_GLOBAL_POSITION) && defined(MODULE_NAME)
+	_ekf.setAuxGlobalPositionEnabled((_pos_est_flags & estimator_status_s::POS_EST_FLAG_AUX_GPOS_FUSION) != 0);
+#endif
+
 	// advertise all topics to ensure consistent uORB instance numbering
 	_estimator_event_flags_pub.advertise();
 	_estimator_innovation_test_ratios_pub.advertise();
@@ -512,8 +520,14 @@ void EKF2::Run()
 
 					// TODO add check for lat and long validity
 					if (cmd_timestamp_valid) {
-						_ekf.resetGlobalPosToExternalObservation(vehicle_command.param5, vehicle_command.param6,
-								accuracy, cmd_timestamp);
+						if (_pos_est_flags & estimator_status_s::POS_EST_FLAG_EXT_GPOS_RESETS) {
+							_ekf.resetGlobalPosToExternalObservation(
+								vehicle_command.param5,
+								vehicle_command.param6,
+								accuracy,
+								cmd_timestamp
+							);
+						}
 					}
 
 
@@ -702,16 +716,30 @@ void EKF2::Run()
 		UpdateBaroSample(ekf2_timestamps);
 #endif // CONFIG_EKF2_BAROMETER
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)
-		UpdateExtVisionSample(ekf2_timestamps);
+
+		if (_pos_est_flags & estimator_status_s::POS_EST_FLAG_VISION_FUSION) {
+			UpdateExtVisionSample(ekf2_timestamps);
+		}
+
 #endif // CONFIG_EKF2_EXTERNAL_VISION
 #if defined(CONFIG_EKF2_OPTICAL_FLOW)
-		UpdateFlowSample(ekf2_timestamps);
+
+		if (_pos_est_flags & estimator_status_s::POS_EST_FLAG_VISION_FUSION) {
+			UpdateFlowSample(ekf2_timestamps);
+		}
+
 #endif // CONFIG_EKF2_OPTICAL_FLOW
 #if defined(CONFIG_EKF2_GNSS)
-		UpdateGpsSample(ekf2_timestamps);
+
+		if ((!_ekf.global_origin_valid() && (_pos_est_flags & estimator_status_s::POS_EST_FLAG_GNSS_INIT))
+		    || (!_is_armed && (_pos_est_flags & estimator_status_s::POS_EST_FLAG_GNSS_DISARMED))
+		    || (_is_armed && (_pos_est_flags & estimator_status_s::POS_EST_FLAG_GNSS_ARMED))) {
+			UpdateGpsSample(ekf2_timestamps);
 # if defined(CONFIG_EKF2_GNSS_YAW)
-		updateGnssHeadingSample(ekf2_timestamps);
+			updateGnssHeadingSample(ekf2_timestamps);
 # endif //CONFIG_EKF2_GNSS_YAW
+		}
+
 #endif // CONFIG_EKF2_GNSS
 #if defined(CONFIG_EKF2_MAGNETOMETER)
 		UpdateMagSample(ekf2_timestamps);
@@ -1865,6 +1893,8 @@ void EKF2::PublishStatus(const hrt_abstime &timestamp)
 			    status.mag_strength_ref_gs);
 #endif // CONFIG_EKF2_MAGNETOMETER
 
+	status.pos_est_flags = _pos_est_flags;
+
 	status.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 	_estimator_status_pub.publish(status);
 }
@@ -2587,8 +2617,11 @@ void EKF2::UpdateSystemFlagsSample(ekf2_timestamps_s &ekf2_timestamps)
 		if (_status_sub.copy(&vehicle_status)
 		    && (ekf2_timestamps.timestamp < vehicle_status.timestamp + 3_s)) {
 
+			// Track armed state for GPS gating
+			_is_armed = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
+
 			// initially set in_air from arming_state (will be overridden if land detector is available)
-			flags.in_air = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
+			flags.in_air = _is_armed;
 
 			// let the EKF know if the vehicle motion is that of a fixed wing (forward flight only relative to wind)
 			flags.is_fixed_wing = (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING);
@@ -2755,6 +2788,9 @@ int EKF2::task_spawn(int argc, char *argv[])
 	int32_t sens_imu_mode = 1;
 	param_get(param_find("SENS_IMU_MODE"), &sens_imu_mode);
 
+	int32_t ekf2_main_pos = 0;
+	param_get(param_find("EKF2_MAIN_POS"), &ekf2_main_pos);
+
 	if (sens_imu_mode == 0) {
 		// ekf selector requires SENS_IMU_MODE = 0
 		multi_mode = true;
@@ -2821,6 +2857,10 @@ int EKF2::task_spawn(int argc, char *argv[])
 
 		const hrt_abstime time_started = hrt_absolute_time();
 		const int multi_instances = math::min(imu_instances * mag_instances, static_cast<int32_t>(EKF2_MAX_INSTANCES));
+
+		const uint8_t main_pos_est_flags = static_cast<uint8_t>(ekf2_main_pos)
+					       | estimator_status_s::POS_EST_FLAG_SELECTABLE;
+
 		int multi_instances_allocated = 0;
 
 		// allocate EKF2 instances until all found or arming
@@ -2849,7 +2889,7 @@ int EKF2::task_spawn(int argc, char *argv[])
 						if (!ekf2_instance_created[imu][mag]) {
 							EKF2 *ekf2_inst = new EKF2(true, px4::ins_instance_to_wq(imu), false);
 
-							if (ekf2_inst && ekf2_inst->multi_init(imu, mag)) {
+							if (ekf2_inst && ekf2_inst->multi_init(imu, mag, main_pos_est_flags)) {
 								int actual_instance = ekf2_inst->instance(); // match uORB instance numbering
 
 								if ((actual_instance >= 0) && (_objects[actual_instance].load() == nullptr)) {
@@ -2858,9 +2898,9 @@ int EKF2::task_spawn(int argc, char *argv[])
 									multi_instances_allocated++;
 									ekf2_instance_created[imu][mag] = true;
 
-									PX4_DEBUG("starting instance %d, IMU:%" PRIu8 " (%" PRIu32 "), MAG:%" PRIu8 " (%" PRIu32 ")", actual_instance,
-										  imu, vehicle_imu_sub.get().accel_device_id,
-										  mag, vehicle_mag_sub.get().device_id);
+									PX4_DEBUG("starting instance %d, IMU:%" PRIu8 " (%" PRIu32 "), MAG:%" PRIu8 " (%" PRIu32 "), flags:0x%02" PRIx8,
+										  actual_instance, imu, vehicle_imu_sub.get().accel_device_id,
+										  mag, vehicle_mag_sub.get().device_id, main_pos_est_flags);
 
 									_ekf2_selector.load()->ScheduleNow();
 
@@ -2871,7 +2911,7 @@ int EKF2::task_spawn(int argc, char *argv[])
 								}
 
 							} else {
-								PX4_ERR("alloc and init failed imu: %" PRIu8 " mag:%" PRIu8, imu, mag);
+								PX4_ERR("alloc and init failed imu: %" PRIu8 " mag:%" PRIu8 " flags:0x%02" PRIx8, imu, mag, main_pos_est_flags);
 								px4_usleep(100000);
 								break;
 							}

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -41,7 +41,7 @@ using matrix::Quatf;
 using matrix::Vector3f;
 
 static constexpr float kDefaultExternalPosAccuracy = 50.0f; // [m]
-static constexpr float kMaxDelaySecondsExternalPosMeasurement = 15.0f; // [s]
+static constexpr uint64_t kMaxAgeExternalPosMeasurement = 15_s;
 
 pthread_mutex_t ekf2_module_mutex = PTHREAD_MUTEX_INITIALIZER;
 static px4::atomic<EKF2 *> _objects[EKF2_MAX_INSTANCES] {};
@@ -485,9 +485,24 @@ void EKF2::Run()
 				if ((_ekf.control_status_flags().wind_dead_reckoning || _ekf.control_status_flags().inertial_dead_reckoning) &&
 				    PX4_ISFINITE(vehicle_command.param2) && PX4_ISFINITE(vehicle_command.param5) && PX4_ISFINITE(vehicle_command.param6)) {
 
-					const float measurement_delay_seconds = math::constrain(vehicle_command.param2, 0.0f,
-										kMaxDelaySecondsExternalPosMeasurement);
-					const uint64_t timestamp_observation = vehicle_command.timestamp - measurement_delay_seconds * 1_s;
+					// Trust the transmission_time from the message to be in flight controller time, ignoring
+					// processing_time.
+					// Cast to double first to avoid unnecessary precission loss
+					const uint64_t cmd_timestamp = static_cast<uint64_t>(static_cast<double>(vehicle_command.param1) * 1_s);
+					bool cmd_timestamp_valid{true};
+
+					// Basic validation of the timestamp
+					if (!PX4_ISFINITE(vehicle_command.param1)) {
+						cmd_timestamp_valid = false;
+					}
+
+					if (cmd_timestamp > hrt_absolute_time()) {
+						cmd_timestamp_valid = false; // Cannot be into the future
+					}
+
+					if (cmd_timestamp < math::max(kMaxAgeExternalPosMeasurement, hrt_absolute_time() - kMaxAgeExternalPosMeasurement)) {
+						cmd_timestamp_valid = false; // Too old
+					}
 
 					float accuracy = kDefaultExternalPosAccuracy;
 
@@ -496,8 +511,12 @@ void EKF2::Run()
 					}
 
 					// TODO add check for lat and long validity
-					_ekf.resetGlobalPosToExternalObservation(vehicle_command.param5, vehicle_command.param6,
-							accuracy, timestamp_observation);
+					if (cmd_timestamp_valid) {
+						_ekf.resetGlobalPosToExternalObservation(vehicle_command.param5, vehicle_command.param6,
+								accuracy, cmd_timestamp);
+					}
+
+
 				}
 			}
 		}

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -235,9 +235,10 @@ EKF2::~EKF2()
 }
 
 #if defined(CONFIG_EKF2_MULTI_INSTANCE)
-bool EKF2::multi_init(int imu, int mag, uint8_t pos_est_flags)
+bool EKF2::multi_init(int imu, int mag, uint8_t pos_est_flags, uint8_t pos_est_group)
 {
 	_pos_est_flags = pos_est_flags;
+	_pos_est_group = pos_est_group;
 
 	_ekf.setFakePositionEnabled((_pos_est_flags & estimator_status_s::POS_EST_FLAG_FAKE_POSITION) != 0);
 
@@ -1894,6 +1895,7 @@ void EKF2::PublishStatus(const hrt_abstime &timestamp)
 #endif // CONFIG_EKF2_MAGNETOMETER
 
 	status.pos_est_flags = _pos_est_flags;
+	status.pos_est_group = _pos_est_group;
 
 	status.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 	_estimator_status_pub.publish(status);
@@ -2789,7 +2791,11 @@ int EKF2::task_spawn(int argc, char *argv[])
 	param_get(param_find("SENS_IMU_MODE"), &sens_imu_mode);
 
 	int32_t ekf2_main_pos = 0;
+	int32_t ekf2_back_pos = 0;
+	int32_t ekf2_back_sel = 0;
 	param_get(param_find("EKF2_MAIN_POS"), &ekf2_main_pos);
+	param_get(param_find("EKF2_BACK_POS"), &ekf2_back_pos);
+	param_get(param_find("EKF2_BACK_SEL"), &ekf2_back_sel);
 
 	if (sens_imu_mode == 0) {
 		// ekf selector requires SENS_IMU_MODE = 0
@@ -2856,17 +2862,29 @@ int EKF2::task_spawn(int argc, char *argv[])
 		}
 
 		const hrt_abstime time_started = hrt_absolute_time();
-		const int multi_instances = math::min(imu_instances * mag_instances, static_cast<int32_t>(EKF2_MAX_INSTANCES));
+		const bool create_backups = (ekf2_back_pos != 0);
+		const uint8_t num_pos_est_groups = create_backups ? 2 : 1;
+		const int multi_instances = math::min(imu_instances * mag_instances * num_pos_est_groups,
+						      static_cast<int32_t>(EKF2_MAX_INSTANCES));
 
+		if (imu_instances * mag_instances * num_pos_est_groups > static_cast<int32_t>(EKF2_MAX_INSTANCES)) {
+			PX4_WARN("requested %" PRId32 " instances exceeds max %d",
+				 imu_instances * mag_instances * num_pos_est_groups, EKF2_MAX_INSTANCES);
+		}
+
+		// Force the main estimator group to always be selectable
 		const uint8_t main_pos_est_flags = static_cast<uint8_t>(ekf2_main_pos)
-					       | estimator_status_s::POS_EST_FLAG_SELECTABLE;
+						   | estimator_status_s::POS_EST_FLAG_SELECTABLE;
+		// Only allow the backup estimator group to be selected if explicitly configured
+		const uint8_t backup_pos_est_flags = static_cast<uint8_t>(ekf2_back_pos)
+						     | (ekf2_back_sel ? estimator_status_s::POS_EST_FLAG_SELECTABLE : 0);
 
 		int multi_instances_allocated = 0;
 
 		// allocate EKF2 instances until all found or arming
 		uORB::SubscriptionData<vehicle_status_s> vehicle_status_sub{ORB_ID(vehicle_status)};
 
-		bool ekf2_instance_created[MAX_NUM_IMUS][MAX_NUM_MAGS] {}; // IMUs * mags
+		bool ekf2_instance_created[MAX_NUM_IMUS][MAX_NUM_MAGS][MAX_NUM_POS_EST_GROUPS] {};
 
 		while ((multi_instances_allocated < multi_instances)
 		       && (vehicle_status_sub.get().arming_state != vehicle_status_s::ARMING_STATE_ARMED)
@@ -2875,51 +2893,57 @@ int EKF2::task_spawn(int argc, char *argv[])
 
 			vehicle_status_sub.update();
 
-			for (uint8_t mag = 0; mag < mag_instances; mag++) {
-				uORB::SubscriptionData<vehicle_magnetometer_s> vehicle_mag_sub{ORB_ID(vehicle_magnetometer), mag};
+			for (uint8_t pos_est_group = estimator_status_s::POS_EST_GROUP_MAIN; pos_est_group < num_pos_est_groups;
+			     pos_est_group++) {
+				const uint8_t pos_est_flags = (pos_est_group == estimator_status_s::POS_EST_GROUP_BACKUP)
+							      ? backup_pos_est_flags : main_pos_est_flags;
 
-				for (uint8_t imu = 0; imu < imu_instances; imu++) {
+				for (uint8_t mag = 0; mag < mag_instances; mag++) {
+					uORB::SubscriptionData<vehicle_magnetometer_s> vehicle_mag_sub{ORB_ID(vehicle_magnetometer), mag};
 
-					uORB::SubscriptionData<vehicle_imu_s> vehicle_imu_sub{ORB_ID(vehicle_imu), imu};
-					vehicle_mag_sub.update();
+					for (uint8_t imu = 0; imu < imu_instances; imu++) {
 
-					// Mag & IMU data must be valid, first mag can be ignored initially
-					if ((vehicle_mag_sub.advertised() || mag == 0) && (vehicle_imu_sub.advertised())) {
+						uORB::SubscriptionData<vehicle_imu_s> vehicle_imu_sub{ORB_ID(vehicle_imu), imu};
+						vehicle_mag_sub.update();
 
-						if (!ekf2_instance_created[imu][mag]) {
-							EKF2 *ekf2_inst = new EKF2(true, px4::ins_instance_to_wq(imu), false);
+						// Mag & IMU data must be valid, first mag can be ignored initially
+						if ((vehicle_mag_sub.advertised() || mag == 0) && (vehicle_imu_sub.advertised())) {
 
-							if (ekf2_inst && ekf2_inst->multi_init(imu, mag, main_pos_est_flags)) {
-								int actual_instance = ekf2_inst->instance(); // match uORB instance numbering
+							if (!ekf2_instance_created[imu][mag][pos_est_group]) {
+								EKF2 *ekf2_inst = new EKF2(true, px4::ins_instance_to_wq(imu), false);
 
-								if ((actual_instance >= 0) && (_objects[actual_instance].load() == nullptr)) {
-									_objects[actual_instance].store(ekf2_inst);
-									success = true;
-									multi_instances_allocated++;
-									ekf2_instance_created[imu][mag] = true;
+								if (ekf2_inst && ekf2_inst->multi_init(imu, mag, pos_est_flags, pos_est_group)) {
+									int actual_instance = ekf2_inst->instance(); // match uORB instance numbering
 
-									PX4_DEBUG("starting instance %d, IMU:%" PRIu8 " (%" PRIu32 "), MAG:%" PRIu8 " (%" PRIu32 "), flags:0x%02" PRIx8,
-										  actual_instance, imu, vehicle_imu_sub.get().accel_device_id,
-										  mag, vehicle_mag_sub.get().device_id, main_pos_est_flags);
+									if ((actual_instance >= 0) && (_objects[actual_instance].load() == nullptr)) {
+										_objects[actual_instance].store(ekf2_inst);
+										success = true;
+										multi_instances_allocated++;
+										ekf2_instance_created[imu][mag][pos_est_group] = true;
 
-									_ekf2_selector.load()->ScheduleNow();
+										PX4_DEBUG("starting instance %d, IMU:%" PRIu8 " (%" PRIu32 "), MAG:%" PRIu8 " (%" PRIu32 "), flags:0x%02" PRIx8,
+											  actual_instance, imu, vehicle_imu_sub.get().accel_device_id,
+											  mag, vehicle_mag_sub.get().device_id, pos_est_flags);
+
+										_ekf2_selector.load()->ScheduleNow();
+
+									} else {
+										PX4_ERR("instance numbering problem instance: %d", actual_instance);
+										delete ekf2_inst;
+										break;
+									}
 
 								} else {
-									PX4_ERR("instance numbering problem instance: %d", actual_instance);
-									delete ekf2_inst;
+									PX4_ERR("alloc and init failed imu: %" PRIu8 " mag:%" PRIu8 " flags:0x%02" PRIx8, imu, mag, pos_est_flags);
+									px4_usleep(100000);
 									break;
 								}
-
-							} else {
-								PX4_ERR("alloc and init failed imu: %" PRIu8 " mag:%" PRIu8 " flags:0x%02" PRIx8, imu, mag, main_pos_est_flags);
-								px4_usleep(100000);
-								break;
 							}
-						}
 
-					} else {
-						px4_usleep(1000); // give the sensors extra time to start
-						break;
+						} else {
+							px4_usleep(1000); // give the sensors extra time to start
+							break;
+						}
 					}
 				}
 			}

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -153,15 +153,19 @@ public:
 	static void unlock_module() { pthread_mutex_unlock(&ekf2_module_mutex); }
 
 #if defined(CONFIG_EKF2_MULTI_INSTANCE)
-	bool multi_init(int imu, int mag);
+	bool multi_init(int imu, int mag, uint8_t pos_est_flags);
 #endif // CONFIG_EKF2_MULTI_INSTANCE
 
 	int instance() const { return _instance; }
+	uint8_t pos_est_flags() const { return _pos_est_flags; }
 
 private:
 
 	static constexpr uint8_t MAX_NUM_IMUS = 4;
 	static constexpr uint8_t MAX_NUM_MAGS = 4;
+
+	uint8_t _pos_est_flags{0}; ///< Position estimation flags bitmask
+	bool _is_armed{false};     ///< Vehicle armed state
 
 	void Run() override;
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -153,7 +153,7 @@ public:
 	static void unlock_module() { pthread_mutex_unlock(&ekf2_module_mutex); }
 
 #if defined(CONFIG_EKF2_MULTI_INSTANCE)
-	bool multi_init(int imu, int mag, uint8_t pos_est_flags);
+	bool multi_init(int imu, int mag, uint8_t pos_est_flags, uint8_t pos_est_group);
 #endif // CONFIG_EKF2_MULTI_INSTANCE
 
 	int instance() const { return _instance; }
@@ -163,8 +163,10 @@ private:
 
 	static constexpr uint8_t MAX_NUM_IMUS = 4;
 	static constexpr uint8_t MAX_NUM_MAGS = 4;
+	static constexpr uint8_t MAX_NUM_POS_EST_GROUPS = 2;
 
 	uint8_t _pos_est_flags{0}; ///< Position estimation flags bitmask
+	uint8_t _pos_est_group{estimator_status_s::POS_EST_GROUP_MAIN};
 	bool _is_armed{false};     ///< Vehicle armed state
 
 	void Run() override;

--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -269,6 +269,7 @@ bool EKF2Selector::UpdateErrorScores()
 			_instance[i].baro_device_id = status.baro_device_id;
 			_instance[i].mag_device_id = status.mag_device_id;
 			_instance[i].pos_est_flags = status.pos_est_flags;
+			_instance[i].pos_est_group = status.pos_est_group;
 
 			if ((i + 1) > _available_instances) {
 				_available_instances = i + 1;
@@ -855,7 +856,8 @@ void EKF2Selector::PrintStatus()
 	for (int i = 0; i < _available_instances; i++) {
 		const EstimatorInstance &inst = _instance[i];
 
-		PX4_INFO("%" PRIu8 ": ACC: %" PRIu32 ", GYRO: %" PRIu32 ", MAG: %" PRIu32 ", flags:0x%02" PRIx8 " %s%s, test ratio: %.7f (%.5f) %s",
+		PX4_INFO("%" PRIu8 ": ACC: %" PRIu32 ", GYRO: %" PRIu32 ", MAG: %" PRIu32 ", flags:0x%02" PRIx8
+			 " %s%s, test ratio: %.7f (%.5f) %s",
 			 inst.instance, inst.accel_device_id, inst.gyro_device_id, inst.mag_device_id,
 			 inst.pos_est_flags,
 			 !(inst.pos_est_flags & estimator_status_s::POS_EST_FLAG_SELECTABLE) ? "non-selectable, " : "",

--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -268,6 +268,7 @@ bool EKF2Selector::UpdateErrorScores()
 			_instance[i].gyro_device_id = status.gyro_device_id;
 			_instance[i].baro_device_id = status.baro_device_id;
 			_instance[i].mag_device_id = status.mag_device_id;
+			_instance[i].pos_est_flags = status.pos_est_flags;
 
 			if ((i + 1) > _available_instances) {
 				_available_instances = i + 1;
@@ -687,11 +688,12 @@ void EKF2Selector::Run()
 	// update combined test ratio for all estimators
 	const bool updated = UpdateErrorScores();
 
-	// if no valid instance then force select first instance with valid IMU
+	// if no valid instance then force select first selectable instance with valid IMU
 	if (_selected_instance == INVALID_INSTANCE) {
 		for (uint8_t i = 0; i < EKF2_MAX_INSTANCES; i++) {
 			if ((_instance[i].accel_device_id != 0)
-			    && (_instance[i].gyro_device_id != 0)) {
+			    && (_instance[i].gyro_device_id != 0)
+			    && (_instance[i].pos_est_flags & estimator_status_s::POS_EST_FLAG_SELECTABLE)) {
 
 				if (SelectInstance(i)) {
 					break;
@@ -722,6 +724,11 @@ void EKF2Selector::Run()
 
 		// loop through all available instances to find if an alternative is available
 		for (int i = 0; i < _available_instances; i++) {
+			// Skip non-selectable instances
+			if (!(_instance[i].pos_est_flags & estimator_status_s::POS_EST_FLAG_SELECTABLE)) {
+				continue;
+			}
+
 			// Use an alternative instance if  -
 			// (healthy and has updated recently)
 			// AND
@@ -848,8 +855,10 @@ void EKF2Selector::PrintStatus()
 	for (int i = 0; i < _available_instances; i++) {
 		const EstimatorInstance &inst = _instance[i];
 
-		PX4_INFO("%" PRIu8 ": ACC: %" PRIu32 ", GYRO: %" PRIu32 ", MAG: %" PRIu32 ", %s, test ratio: %.7f (%.5f) %s",
+		PX4_INFO("%" PRIu8 ": ACC: %" PRIu32 ", GYRO: %" PRIu32 ", MAG: %" PRIu32 ", flags:0x%02" PRIx8 " %s%s, test ratio: %.7f (%.5f) %s",
 			 inst.instance, inst.accel_device_id, inst.gyro_device_id, inst.mag_device_id,
+			 inst.pos_est_flags,
+			 !(inst.pos_est_flags & estimator_status_s::POS_EST_FLAG_SELECTABLE) ? "non-selectable, " : "",
 			 inst.healthy.get_state() ? "healthy" : "unhealthy",
 			 (double)inst.combined_test_ratio, (double)inst.relative_test_ratio,
 			 (_selected_instance == i) ? "*" : "");

--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -126,6 +126,8 @@ private:
 		uint32_t baro_device_id{0};
 		uint32_t mag_device_id{0};
 
+		uint8_t pos_est_flags{0};
+
 		hrt_abstime time_last_selected{0};
 		hrt_abstime time_last_no_warning{0};
 

--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -127,6 +127,7 @@ private:
 		uint32_t mag_device_id{0};
 
 		uint8_t pos_est_flags{0};
+		uint8_t pos_est_group{0};
 
 		hrt_abstime time_last_selected{0};
 		hrt_abstime time_last_no_warning{0};

--- a/src/modules/ekf2/params_multi.yaml
+++ b/src/modules/ekf2/params_multi.yaml
@@ -22,3 +22,22 @@ parameters:
       reboot_required: true
       min: 0
       max: 4
+    EKF2_MAIN_POS:
+      description:
+        short: Main estimator position estimation flags
+        long: Bitmask controlling which position estimation sources are enabled
+          for main EKF instances. Main estimators are always selectable.
+          Requires SENS_IMU_MODE 0.
+      type: bitmask
+      default: 127
+      reboot_required: true
+      min: 0
+      max: 127
+      bit:
+        0: Initialize origin with GNSS
+        1: Fuse GNSS while disarmed
+        2: Fuse GNSS while armed
+        3: Accept external position resets
+        4: Fuse auxiliary global position
+        5: Fuse vision and optical flow
+        6: Fuse fake position

--- a/src/modules/ekf2/params_multi.yaml
+++ b/src/modules/ekf2/params_multi.yaml
@@ -73,3 +73,18 @@ parameters:
       values:
         0: Not selectable
         1: Selectable
+    EKF2_TRN_PUB:
+      description:
+        short: TRN test data source
+        long: Which estimator instance to publish on AVIANT_TRN_TEST_DATA.
+          None disables publishing. Selected publishes the currently selected
+          estimator. First backup publishes the first backup estimator instance.
+      type: int32
+      default: 0
+      reboot_required: false
+      min: 0
+      max: 2
+      values:
+        0: None
+        1: Selected
+        2: First backup

--- a/src/modules/ekf2/params_multi.yaml
+++ b/src/modules/ekf2/params_multi.yaml
@@ -41,3 +41,35 @@ parameters:
         4: Fuse auxiliary global position
         5: Fuse vision and optical flow
         6: Fuse fake position
+    EKF2_BACK_POS:
+      description:
+        short: Backup estimator position estimation flags
+        long: Bitmask controlling which position estimation sources are enabled
+          for backup EKF instances. Set 0 to disable backup instances. Backup
+          instances double the number of estimators. Requires SENS_IMU_MODE 0.
+      type: bitmask
+      default: 0
+      reboot_required: true
+      min: 0
+      max: 127
+      bit:
+        0: Initialize origin with GNSS
+        1: Fuse GNSS while disarmed
+        2: Fuse GNSS while armed
+        3: Accept external position resets
+        4: Fuse auxiliary global position
+        5: Fuse vision and optical flow
+        6: Fuse fake position
+    EKF2_BACK_SEL:
+      description:
+        short: Backup estimator selectable
+        long: When enabled, the EKF2 selector can switch to backup estimator
+          instances. When disabled, backup estimators run in the background only.
+      type: int32
+      default: 0
+      reboot_required: true
+      min: 0
+      max: 1
+      values:
+        0: Not selectable
+        1: Selectable

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1453,6 +1453,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("AVIANT_INDICATOR_MOTORS", 1.0f);
 		configure_stream_local("AVIANT_INDICATOR_TEMP_FC", 1.0f);
 		configure_stream_local("AVIANT_NAV", 10.0f);
+		configure_stream_local("AVIANT_TRN_TEST_DATA", 10.0f);
 #endif // MAVLINK_ENABLED_AVIANT
 
 #if !defined(CONSTRAINED_FLASH)

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -127,6 +127,7 @@
 #include "streams/AVIANT_INDICATOR_MOTORS.hpp"
 #include "streams/AVIANT_INDICATOR_TEMP_FC.hpp"
 #include "streams/AVIANT_NAV.hpp"
+#include "streams/AVIANT_TRN_TEST_DATA.hpp"
 #endif // MAVLINK_ENABLED_AVIANT
 
 #if defined(MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS)
@@ -529,6 +530,9 @@ static const StreamListItem streams_list[] = {
 #if defined (AVIANT_NAV_HPP)
 	create_stream_list_item<MavlinkStreamAviantNav>(),
 #endif // AVIANT_NAV_HPP
+#if defined (AVIANT_TRN_TEST_DATA_HPP)
+	create_stream_list_item<MavlinkStreamAviantTrnTestData>(),
+#endif // AVIANT_TRN_TEST_DATA_HPP
 };
 
 const char *get_stream_name(const uint16_t msg_id)

--- a/src/modules/mavlink/streams/AVIANT_TRN_TEST_DATA.hpp
+++ b/src/modules/mavlink/streams/AVIANT_TRN_TEST_DATA.hpp
@@ -1,0 +1,179 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2024 Aviant. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef AVIANT_TRN_TEST_DATA_HPP
+#define AVIANT_TRN_TEST_DATA_HPP
+
+#include <uORB/topics/estimator_status.h>
+#include <uORB/topics/estimator_selector_status.h>
+#include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/vehicle_angular_velocity.h>
+
+class MavlinkStreamAviantTrnTestData : public MavlinkStream
+{
+public:
+	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamAviantTrnTestData(mavlink); }
+
+	static constexpr const char *get_name_static() { return "AVIANT_TRN_TEST_DATA"; }
+	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_AVIANT_TRN_TEST_DATA; }
+
+	const char *get_name() const override { return get_name_static(); }
+	uint16_t get_id() override { return get_id_static(); }
+
+	unsigned get_size() override
+	{
+		return (_trn_instance >= 0) ? MAVLINK_MSG_ID_AVIANT_TRN_TEST_DATA_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES : 0;
+	}
+
+private:
+	static constexpr uint8_t MAX_INSTANCES = 9;
+
+	// EKF2_TRN_PUB values
+	static constexpr int32_t TRN_PUB_NONE = 0;
+	static constexpr int32_t TRN_PUB_SELECTED = 1;
+	static constexpr int32_t TRN_PUB_FIRST_BACKUP = 2;
+
+	explicit MavlinkStreamAviantTrnTestData(Mavlink *mavlink) : MavlinkStream(mavlink) {}
+
+	int8_t _trn_instance{-1};
+	int32_t _trn_pub_mode{-1}; // -1 = not yet read
+
+	uORB::Subscription _local_pos_sub{ORB_ID(estimator_local_position)};
+	uORB::Subscription _attitude_sub{ORB_ID(estimator_attitude)};
+	uORB::Subscription _angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};
+	uORB::Subscription _selector_status_sub{ORB_ID(estimator_selector_status)};
+
+	void subscribe_to_instance(uint8_t inst)
+	{
+		_trn_instance = inst;
+		_local_pos_sub = uORB::Subscription{ORB_ID(estimator_local_position), inst};
+		_attitude_sub = uORB::Subscription{ORB_ID(estimator_attitude), inst};
+	}
+
+	void discover_trn_instance()
+	{
+		if (_trn_pub_mode < 0) {
+			_trn_pub_mode = TRN_PUB_NONE;
+			param_get(param_find("EKF2_TRN_PUB"), &_trn_pub_mode);
+		}
+
+		if (_trn_pub_mode == TRN_PUB_NONE) {
+			return;
+		}
+
+		if (_trn_pub_mode == TRN_PUB_SELECTED) {
+			estimator_selector_status_s selector_status;
+
+			if (_selector_status_sub.copy(&selector_status)) {
+				subscribe_to_instance(selector_status.primary_instance);
+			}
+
+		} else if (_trn_pub_mode == TRN_PUB_FIRST_BACKUP) {
+			for (uint8_t i = 0; i < MAX_INSTANCES; i++) {
+				uORB::Subscription status_sub{ORB_ID(estimator_status), i};
+				estimator_status_s status;
+
+				if (status_sub.copy(&status) && status.pos_est_group == estimator_status_s::POS_EST_GROUP_BACKUP) {
+					subscribe_to_instance(i);
+					PX4_INFO("AVIANT_TRN_TEST_DATA: using backup EKF instance %d", i);
+					return;
+				}
+			}
+		}
+	}
+
+	bool send() override
+	{
+		if (_trn_instance < 0) {
+			discover_trn_instance();
+
+			if (_trn_instance < 0) {
+				return false;
+			}
+		}
+
+		// For "Selected" mode, track primary instance changes
+		if (_trn_pub_mode == TRN_PUB_SELECTED) {
+			estimator_selector_status_s selector_status;
+
+			if (_selector_status_sub.update(&selector_status)) {
+				if (selector_status.primary_instance != static_cast<uint8_t>(_trn_instance)) {
+					subscribe_to_instance(selector_status.primary_instance);
+				}
+			}
+		}
+
+		vehicle_local_position_s local_pos;
+		vehicle_attitude_s attitude;
+		vehicle_angular_velocity_s angular_velocity;
+
+		if (_local_pos_sub.update(&local_pos)) {
+			_attitude_sub.copy(&attitude);
+			_angular_velocity_sub.copy(&angular_velocity);
+
+			mavlink_aviant_trn_test_data_t msg{};
+
+			msg.time_boot_ms = local_pos.timestamp / 1000;
+
+			// Position
+			msg.x = local_pos.x;
+			msg.y = local_pos.y;
+			msg.z = local_pos.z;
+
+			// Velocity
+			msg.vx = local_pos.vx;
+			msg.vy = local_pos.vy;
+			msg.vz = local_pos.vz;
+
+			// Attitude quaternion
+			msg.q1 = attitude.q[0];
+			msg.q2 = attitude.q[1];
+			msg.q3 = attitude.q[2];
+			msg.q4 = attitude.q[3];
+
+			// Angular velocity
+			msg.angular_velocity_x = angular_velocity.xyz[0];
+			msg.angular_velocity_y = angular_velocity.xyz[1];
+			msg.angular_velocity_z = angular_velocity.xyz[2];
+
+			mavlink_msg_aviant_trn_test_data_send_struct(_mavlink->get_channel(), &msg);
+
+			return true;
+		}
+
+		return false;
+	}
+};
+
+#endif // AVIANT_TRN_TEST_DATA_HPP


### PR DESCRIPTION
We have a project with the company KEF for flying with their GNSS-denied navigation solution "Terrain Relative Navigation (TRN)". It's originally designed for defence usage, but we want to use it in a civil context as a backup in case we are exposed to GNSS jamming, spoofing or other loss of GNSS fix.

Their solution takes in a 10Hz pose and approximate position estimate along with a video stream. They then use a neural algorithm to match the video feed with satellite imagery, and use that to estimate the drone's position, which is sent back to the drone with the EXTERNAL_POSITION_ESTIMATE message.

We have done open-loop testing and data capture, and we have seen some promising-ish results. However, all those tests were cheating, because they always used the drone's GNSS position to bootstrap their image search. In a real GNSS-denied scenario, the initial guess will be much farther off, which will probably deteriorate the estimate. We want to test this now, by running the algorithm closed-loop: only estimate the global position using only the TRN input, i.e. without GNSS.

However, until we have verified the accuracy of such a closed-loop estimate, we want to not use that estimator for flight just yet -- just have it running in the background. This PR addresses that challenge, by spawning two estimator groups: On main group, which is just the 3 estimators we have always ran, and a backup group which we will only feed TRN data, and which will not be selected by the estimator for usage.

Furthermore, we want to do this safely in production, so that we can collect data in commercial flights. We previously had a branch for this, which wasn't intended for production flight (https://github.com/aviant-tech/PX4-Autopilot/pull/132). We have flown with it, but it is too hacky to consider safe in production -- the intention of this PR is to be production-worthy.

Safety requirements (please focus on these in the review):

1. Behavior with default parameters SHALL NOT be different than before this PR.
2. When flying with "External position resets" disabled in EKF2_MAIN_POS, there SHALL NOT be a way for EXTERNAL_POSITION_RESET to affect the main estimator group.
3. When EKF2_BACK_SEL=0, there SHALL NOT be a way the backup estimators are ever used for flight.

I claim that with the requirements above satisfied, this code is safe to fly in production.

Some design choices:
- To remain consistent with previous norms, we spin up as many background estimators as we have main estimators (i.e. one per IMU).
- I have kept most EKF code ignorant of what TRN is. Instead, we just have a set of "position estimation flags" which determine which global position sources are used.
- There is intentionally almost no difference between the MAIN and BACKUP estimator groups, unless they are configured differently in parameters (and they should). The only exception is that MAIN is always selectable by the EKF.
- I don't have any tests, because I tried for a long time to implement them nicely but they just created more complexity than it was worth.
