### PR TITLE
fix(navigator): update mission index when item is NAV_CMD_DO_JUMP#168

### DIFF
--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
@@ -314,6 +314,14 @@ bool FeasibilityChecker::checkMissionItemValidity(mission_item_s &mission_item, 
 		return false;
 	}
 
+	if ((mission_item.nav_cmd == NAV_CMD_DO_JUMP) && (current_index == mission_item.do_jump_mission_index)) {
+
+		mavlink_log_critical(_mavlink_log_pub, "Mission rejected: DO_JUMP item %i points to itself \t", (int)current_index + 1);
+		events::send<uint16_t>(events::ID("navigator_mis_do_jump_point_to_itslef"), {events::Log::Error, events::LogInternal::Warning},
+				       "Mission rejected: DO_JUMP item {1} points to itself", current_index + 1);
+		return false;
+	}
+
 	return true;
 }
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -186,6 +186,21 @@ Mission::do_need_move_to_takeoff()
 
 void Mission::setActiveMissionItems()
 {
+	if (_mission_item.nav_cmd == NAV_CMD_DO_JUMP) {
+
+		int32_t resolved_index = _mission.current_seq;
+		mission_item_s resolved_item;
+
+		if (getNonJumpItem(resolved_index, resolved_item, true, true) == PX4_OK) {
+			set_current_mission_index(resolved_index);
+
+		} else {
+			PX4_ERR("Issue with getNonJumpItem for index %d", (int)resolved_index);
+		}
+
+		return;
+	}
+
 	/* Get mission item that comes after current if available */
 	static constexpr size_t max_num_next_items{2u};
 	int32_t next_mission_items_index[max_num_next_items];


### PR DESCRIPTION
#### Description

This PR fixes a bug where the vehicle initiates an unintended landing after a user manually sets the mission index to a NAV_CMD_DO_JUMP item (Command 177).

#### The Problem

When a mission plan includes a "Jump to Item," and a user manually trigger that index (pymavlink script or modified QGC), the navigator gets into a bad state. Because a jump command is a logic gate and doesn't contain actual coordinates, the vehicle loses its mission triplets.

Without valid position setpoints to follow, the drone treats the mission as broken or empty and defaults to landing.

#### The Solution

The solution is to let the navigator process the jump logic in setActiveMissionItems().

When the navigator detects that the current mission item is a NAV_CMD_DO_JUMP, it immediately updates the index to the jump's target waypoint.

By doing this, the navigator always ends up with a coordinate-based waypoint to fly to, ensuring the setpoint triplets remain valid and the vehicle stays in the air.