### PR TITLE
aviant: check two-sided current anomaly

### DIFF
--- a/src/modules/aviant/thrust/Thrust.cpp
+++ b/src/modules/aviant/thrust/Thrust.cpp
@@ -284,17 +284,21 @@ void Thrust::updateAnomalousCurrent(aviant_motors_s *out, float v_bat, float cur
 	out->anomalous_current_filtered_ca = (int16_t)roundf(math::constrain(filtered_anomaly * 100.0f,
 					     (float)INT16_MIN, (float)INT16_MAX));
 
-	// warn/crit pct act as feature switches: 0 disables that level.
-	// cur_min is a noise floor on top of those (default 0 = no floor).
-	const float cur_min = _param_av_thr_cur_min.get();
-	const float crit_pct = _param_av_thr_crit_pct.get();
-	const float warn_pct = _param_av_thr_warn_pct.get();
-	const bool above_min = filtered_anomaly >= cur_min;
+	const float crit_hi = _param_av_thr_cri_hi_a.get();
+	const float crit_lo = _param_av_thr_cri_lo_a.get();
+	const float warn_hi = _param_av_thr_wrn_hi_a.get();
+	const float warn_lo = _param_av_thr_wrn_lo_a.get();
 
-	if (crit_pct > 0.0f && above_min && filtered_anomaly >= predicted_current * (crit_pct / 100.0f)) {
+	if (crit_hi > 0.0f && filtered_anomaly >= crit_hi) {
 		out->anomalous_current_status = aviant_motors_s::STATE_CRITICAL;
 
-	} else if (warn_pct > 0.0f && above_min && filtered_anomaly >= predicted_current * (warn_pct / 100.0f)) {
+	} else if (crit_lo > 0.0f && filtered_anomaly <= -crit_lo) {
+		out->anomalous_current_status = aviant_motors_s::STATE_CRITICAL;
+
+	} else if (warn_hi > 0.0f && filtered_anomaly >= warn_hi) {
+		out->anomalous_current_status = aviant_motors_s::STATE_WARNING;
+
+	} else if (warn_lo > 0.0f && filtered_anomaly <= -warn_lo) {
 		out->anomalous_current_status = aviant_motors_s::STATE_WARNING;
 
 	} else {

--- a/src/modules/aviant/thrust/Thrust.hpp
+++ b/src/modules/aviant/thrust/Thrust.hpp
@@ -117,10 +117,11 @@ private:
 		(ParamFloat<px4::params::AV_THR_CUR_TAU>) _param_av_thr_cur_tau,
 		(ParamFloat<px4::params::AV_THR_VPHA_TAU>) _param_av_thr_vpha_tau,
 
-		// Anomalous current thresholds (percentage of predicted + minimum)
-		(ParamFloat<px4::params::AV_THR_WARN_PCT>) _param_av_thr_warn_pct,
-		(ParamFloat<px4::params::AV_THR_CRIT_PCT>) _param_av_thr_crit_pct,
-		(ParamFloat<px4::params::AV_THR_CUR_MIN>) _param_av_thr_cur_min,
+		// Anomalous current thresholds
+		(ParamFloat<px4::params::AV_THR_CRI_LO_A>) _param_av_thr_cri_lo_a,
+		(ParamFloat<px4::params::AV_THR_WRN_LO_A>) _param_av_thr_wrn_lo_a,
+		(ParamFloat<px4::params::AV_THR_WRN_HI_A>) _param_av_thr_wrn_hi_a,
+		(ParamFloat<px4::params::AV_THR_CRI_HI_A>) _param_av_thr_cri_hi_a,
 
 		// Top motor phase voltage
 		(ParamFloat<px4::params::AV_THR_TOP_WRN_V>) _param_av_thr_top_wrn_v,

--- a/src/modules/aviant/thrust/params.c
+++ b/src/modules/aviant/thrust/params.c
@@ -99,38 +99,52 @@ PARAM_DEFINE_FLOAT(AV_THR_PSH_K, 0.0f);
 PARAM_DEFINE_FLOAT(AV_THR_PSH_VREF, 0.0f);
 
 /**
- * Anomalous current warning percentage
+ * Anomalous current critical low threshold
  *
- * Warning when error >= predicted * pct/100 AND error >= minimum.
- *
- * @group Aviant
- * @unit %
- * @decimal 0
- * @min 0
- */
-PARAM_DEFINE_FLOAT(AV_THR_WARN_PCT, 0.0f);
-
-/**
- * Anomalous current minimum error
- *
- * Common minimum for both warning and critical thresholds.
+ * Critical when filtered error <= -AV_THR_CRI_LO_A. 0 disables.
  *
  * @group Aviant
  * @unit A
  * @decimal 1
  * @min 0
  */
-PARAM_DEFINE_FLOAT(AV_THR_CUR_MIN, 0.0f);
+PARAM_DEFINE_FLOAT(AV_THR_CRI_LO_A, 0.0f);
 
 /**
- * Anomalous current critical percentage
+ * Anomalous current warning low threshold
+ *
+ * Warning when filtered error <= -AV_THR_WRN_LO_A. 0 disables.
  *
  * @group Aviant
- * @unit %
- * @decimal 0
+ * @unit A
+ * @decimal 1
  * @min 0
  */
-PARAM_DEFINE_FLOAT(AV_THR_CRIT_PCT, 0.0f);
+PARAM_DEFINE_FLOAT(AV_THR_WRN_LO_A, 0.0f);
+
+/**
+ * Anomalous current warning high threshold
+ *
+ * Warning when filtered error >= AV_THR_WRN_HI_A. 0 disables.
+ *
+ * @group Aviant
+ * @unit A
+ * @decimal 1
+ * @min 0
+ */
+PARAM_DEFINE_FLOAT(AV_THR_WRN_HI_A, 0.0f);
+
+/**
+ * Anomalous current critical high threshold
+ *
+ * Critical when filtered error >= AV_THR_CRI_HI_A. 0 disables.
+ *
+ * @group Aviant
+ * @unit A
+ * @decimal 1
+ * @min 0
+ */
+PARAM_DEFINE_FLOAT(AV_THR_CRI_HI_A, 0.0f);
 
 /**
  * Anomalous current LPF time constant


### PR DESCRIPTION
PRevious code only detected increases in current realtive to model. We are mostly interested in the opposite, since in BOMI the model will underpredict.

However, we track both sides, since an increase in current relative to model can be used to warn icing-like scenarios