### PR TITLE
navigator: avoid RTL failsafe for MR VTOL waypoints

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -284,7 +284,9 @@ void Mission::setActiveMissionItems()
 		}
 
 	} else {
-		handleVtolTransition(new_work_item_type, next_mission_items, num_found_items);
+		// Non-position items (e.g. DO_VTOL_TRANSITION) need no special handling here.
+		// issue_command() below publishes the command and is_mission_item_reached_or_completed()
+		// waits for completion.
 	}
 
 	// Only set the previous position item if the current one really changed
@@ -422,39 +424,6 @@ void Mission::handleTakeoff(WorkItemType &new_work_item_type, mission_item_s nex
 		_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
 		_mission_item.autocontinue = true;
 		_mission_item.time_inside = 0.0f;
-	}
-}
-
-void Mission::handleVtolTransition(WorkItemType &new_work_item_type, mission_item_s next_mission_items[],
-				   size_t &num_found_items)
-{
-	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-
-	/* turn towards next waypoint before MC to FW transition */
-	if (_mission_item.nav_cmd == NAV_CMD_DO_VTOL_TRANSITION
-	    && _work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT
-	    && new_work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT
-	    && _vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
-	    && !_land_detected_sub.get().landed
-	    && (num_found_items > 0u)) {
-
-		new_work_item_type = WorkItemType::WORK_ITEM_TYPE_ALIGN_HEADING;
-
-		set_align_mission_item(&_mission_item, &next_mission_items[0u]);
-
-		/* set position setpoint to target during the transition */
-		mission_item_to_position_setpoint(next_mission_items[0u], &pos_sp_triplet->current);
-	}
-
-	/* yaw is aligned now */
-	if (_work_item_type == WorkItemType::WORK_ITEM_TYPE_ALIGN_HEADING &&
-	    new_work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) {
-
-		new_work_item_type = WorkItemType::WORK_ITEM_TYPE_DEFAULT;
-
-		pos_sp_triplet->previous = pos_sp_triplet->current;
-		// keep current setpoints (FW position controller generates wp to track during transition)
-		pos_sp_triplet->current.type = position_setpoint_s::SETPOINT_TYPE_POSITION;
 	}
 }
 

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -92,8 +92,5 @@ private:
 
 	void handleTakeoff(WorkItemType &new_work_item_type, mission_item_s next_mission_items[], size_t &num_found_items);
 
-	void handleVtolTransition(WorkItemType &new_work_item_type, mission_item_s next_mission_items[],
-				  size_t &num_found_items);
-
 	bool _need_mission_save{false};
 };

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -873,21 +873,6 @@ MissionBlock::copy_position_if_valid(struct mission_item_s *const mission_item,
 }
 
 void
-MissionBlock::set_align_mission_item(struct mission_item_s *const mission_item,
-				     const struct mission_item_s *const mission_item_next) const
-{
-	mission_item->nav_cmd = NAV_CMD_WAYPOINT;
-	copy_position_if_valid(mission_item, &(_navigator->get_position_setpoint_triplet()->current));
-	mission_item->altitude_is_relative = false;
-	mission_item->autocontinue = true;
-	mission_item->time_inside = 0.0f;
-	mission_item->yaw = get_bearing_to_next_waypoint(
-				    _navigator->get_global_position()->lat, _navigator->get_global_position()->lon,
-				    mission_item_next->lat, mission_item_next->lon);
-	mission_item->force_heading = true;
-}
-
-void
 MissionBlock::initialize()
 {
 	_mission_item.lat = (double)NAN;

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -139,12 +139,6 @@ public:
 	void copy_position_if_valid(struct mission_item_s *const mission_item,
 				    const struct position_setpoint_s *const setpoint) const;
 
-	/**
-	 * Create mission item to align towards next waypoint
-	 */
-	void set_align_mission_item(struct mission_item_s *const mission_item,
-				    const struct mission_item_s *const mission_item_next) const;
-
 protected:
 	/**
 	 * @brief heading mode for setting navigation items


### PR DESCRIPTION
When the navigator is in MR and encounters a DO_VTOL_TRANSITION waypoint, it tells mission module to not consider that waypoint finished until its heading points towards the next waypoint. However, the position setpoint is incorrectly set at the next waypoint, and no action is taken to actually align the yaw. Therefore, the vehicle would just move towards the next waypoint for MIS_YAW_TMT and then failsafe RTL.

This commit removes this logic entirely, as it seems to be remains from when the mission code was structured differently. We end up with behavior that matches the pilot expectation: when a DO_VTOL_TRANSITION waypoint is activated, the drone behaves as if it received DO_VTOL_TRANSITION from the GCS.

Before:

https://github.com/user-attachments/assets/c026cce5-a862-4efe-a3a0-93a0b613aa14

After:

https://github.com/user-attachments/assets/c12423d0-dba8-4c97-974f-c231aabeb102

