### PR TITLE
navigator: increase stack by 10%

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1094,7 +1094,7 @@ int Navigator::task_spawn(int argc, char *argv[])
 	_task_id = px4_task_spawn_cmd("navigator",
 				      SCHED_DEFAULT,
 				      SCHED_PRIORITY_NAVIGATION,
-				      PX4_STACK_ADJUSTED(2160),
+				      PX4_STACK_ADJUSTED(2416),
 				      (px4_main_t)&run_trampoline,
 				      (char *const *)argv);
 


### PR DESCRIPTION
Fixes warnings `[load_mon] navigator low on stack! (284 bytes left)`

AI analysis https://aviant.atlassian.net/wiki/spaces/TECHNICAL/pages/2251685904/Memory+Stack+Usage+Analysis+NT15+NT16+NT17+NT19+2026-01-01+to+2026-04-20 shows we have 
~300kB unused memory, so 256 more bytes should be fine