### PR TITLE
gps: implement soft-reset jamming inhibition and extend SensorGps.msg

### DIFF
--- a/msg/SensorGps.msg
+++ b/msg/SensorGps.msg
@@ -36,6 +36,7 @@ uint8 JAMMING_STATE_WARNING  = 2
 uint8 JAMMING_STATE_CRITICAL = 3
 uint8 jamming_state		# indicates whether jamming has been detected or suspected by the receivers. O: Unknown, 1: OK, 2: Warning, 3: Critical
 int32 jamming_indicator		# indicates jamming is occurring
+bool jamming_state_inhibited # indicates whether we are in the inhibited JAMMING_STATE_CRITICAL state.
 
 uint8 SPOOFING_STATE_UNKNOWN   = 0
 uint8 SPOOFING_STATE_NONE      = 1


### PR DESCRIPTION
This PR addresses false JAMMING_STATE_CRITICAL reports that occur during u-blox (UBX) module reconfigurations or soft resets. 

See: https://github.com/aviant-tech/PX4-GPSDrivers/pull/12 