### PR TITLE
hack: add AUX6 to force select backup estimator

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -735,10 +735,23 @@ void EKF2::Run()
 		if ((!_ekf.global_origin_valid() && (_pos_est_flags & estimator_status_s::POS_EST_FLAG_GNSS_INIT))
 		    || (!_is_armed && (_pos_est_flags & estimator_status_s::POS_EST_FLAG_GNSS_DISARMED))
 		    || (_is_armed && (_pos_est_flags & estimator_status_s::POS_EST_FLAG_GNSS_ARMED))) {
-			UpdateGpsSample(ekf2_timestamps);
+
+			vehicle_status_s vehicle_status;
+			_status_sub.copy(&vehicle_status);
+
+			bool allow_gnss_fusion = true;
+
+			if (_pos_est_group == estimator_status_s::POS_EST_GROUP_BACKUP) {
+				allow_gnss_fusion = (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING);
+			}
+
+			if (allow_gnss_fusion) {
+
+				UpdateGpsSample(ekf2_timestamps);
 # if defined(CONFIG_EKF2_GNSS_YAW)
-			updateGnssHeadingSample(ekf2_timestamps);
+				updateGnssHeadingSample(ekf2_timestamps);
 # endif //CONFIG_EKF2_GNSS_YAW
+			}
 		}
 
 #endif // CONFIG_EKF2_GNSS

--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -109,6 +109,16 @@ void EKF2Selector::PrintInstanceChange(const uint8_t old_instance, uint8_t new_i
 
 bool EKF2Selector::SelectInstance(uint8_t ekf_instance)
 {
+	//Inform pilot so we know if it works
+	if (ekf_instance != _selected_instance && ekf_instance != 0xFF && _selected_instance != 0xFF) {
+		// Determine the name of the new source
+		const char *source_name = (_instance[ekf_instance].pos_est_group == estimator_status_s::POS_EST_GROUP_BACKUP) ?
+					  "BACKUP (TRN)" : "MAIN (GPS)";
+
+		// Send notification to GCS
+		mavlink_log_info(&_mavlink_log_pub, "Estimator changed to %s", source_name);
+	}
+
 	if ((ekf_instance != _selected_instance) && (ekf_instance < _available_instances)) {
 		// update sensor_selection immediately
 		sensor_selection_s sensor_selection{};
@@ -294,6 +304,35 @@ bool EKF2Selector::UpdateErrorScores()
 			}
 
 			float combined_test_ratio = fmaxf(0.5f * (status.vel_test_ratio + status.pos_test_ratio), status.hgt_test_ratio);
+
+			_manual_control_input_sub.update(&_mc_input);
+
+			rc_channels_s rc_channels{};
+			_rc_channels_sub.copy(&rc_channels);
+
+			bool rc_invalid = rc_channels.signal_lost || (hrt_elapsed_time(&rc_channels.timestamp) > 3_s);
+
+			if (rc_invalid) {
+				//Override if RC is invalid so we can switch to the MAIN estimator automatically
+				_mc_input.aux6 = 0.0f;
+			}
+
+			// If the RC switch assigned to AUX6 is engaged, force a switch to the BACKUP estimator by
+			// artificially inflating the MAIN estimator's combined_test_ratio. Otherwise, inflate
+			// the BACKUP estimator's ratio to ensure the MAIN estimator is selected.
+			if (_mc_input.aux6 >= 0.5f) {
+
+				if (_instance[i].pos_est_group == estimator_status_s::POS_EST_GROUP_MAIN)  {
+					combined_test_ratio += 2.0f;
+				}
+
+			} else {
+
+				if (_instance[i].pos_est_group == estimator_status_s::POS_EST_GROUP_BACKUP
+				   )  {
+					combined_test_ratio += 2.0f;
+				}
+			}
 
 			_instance[i].combined_test_ratio = combined_test_ratio;
 

--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -307,12 +307,11 @@ bool EKF2Selector::UpdateErrorScores()
 
 			_manual_control_input_sub.update(&_mc_input);
 
-			rc_channels_s rc_channels{};
-			_rc_channels_sub.copy(&rc_channels);
+			vehicle_status_s vehicle_status;
+			_vehicle_status_sub.copy(&vehicle_status);
 
-			bool rc_invalid = rc_channels.signal_lost || (hrt_elapsed_time(&rc_channels.timestamp) > 3_s);
+			if (vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL) {
 
-			if (rc_invalid) {
 				//Override if RC is invalid so we can switch to the MAIN estimator automatically
 				_mc_input.aux6 = 0.0f;
 			}

--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -48,10 +48,10 @@
 #include <uORB/topics/estimator_selector_status.h>
 #include <uORB/topics/estimator_status.h>
 #include <uORB/topics/manual_control_setpoint.h>
-#include <uORB/topics/rc_channels.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/sensor_selection.h>
 #include <uORB/topics/sensors_status_imu.h>
+#include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_global_position.h>
@@ -239,7 +239,7 @@ private:
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 	uORB::Subscription _sensors_status_imu{ORB_ID(sensors_status_imu)};
 	uORB::Subscription _manual_control_input_sub{ORB_ID(manual_control_input)};
-	uORB::Subscription _rc_channels_sub{ORB_ID(rc_channels)};
+	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 
 	// Publications
 	uORB::Publication<estimator_selector_status_s> _estimator_selector_status_pub{ORB_ID(estimator_selector_status)};

--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -47,6 +47,8 @@
 #include <uORB/Publication.hpp>
 #include <uORB/topics/estimator_selector_status.h>
 #include <uORB/topics/estimator_status.h>
+#include <uORB/topics/manual_control_setpoint.h>
+#include <uORB/topics/rc_channels.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/sensor_selection.h>
 #include <uORB/topics/sensors_status_imu.h>
@@ -55,6 +57,7 @@
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_odometry.h>
 #include <uORB/topics/wind.h>
+#include <systemlib/mavlink_log.h>
 
 #if CONSTRAINED_MEMORY
 # define EKF2_MAX_INSTANCES 2
@@ -231,8 +234,12 @@ private:
 	uint8_t _global_position_instance_prev{INVALID_INSTANCE};
 	uint8_t _odometry_instance_prev{INVALID_INSTANCE};
 
+	manual_control_setpoint_s _mc_input{};
+
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 	uORB::Subscription _sensors_status_imu{ORB_ID(sensors_status_imu)};
+	uORB::Subscription _manual_control_input_sub{ORB_ID(manual_control_input)};
+	uORB::Subscription _rc_channels_sub{ORB_ID(rc_channels)};
 
 	// Publications
 	uORB::Publication<estimator_selector_status_s> _estimator_selector_status_pub{ORB_ID(estimator_selector_status)};
@@ -242,6 +249,8 @@ private:
 	uORB::Publication<vehicle_local_position_s>    _vehicle_local_position_pub{ORB_ID(vehicle_local_position)};
 	uORB::Publication<vehicle_odometry_s>          _vehicle_odometry_pub{ORB_ID(vehicle_odometry)};
 	uORB::Publication<wind_s>             _wind_pub{ORB_ID(wind)};
+
+	orb_advert_t 	_mavlink_log_pub {nullptr};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::EKF2_SEL_ERR_RED>) _param_ekf2_sel_err_red,


### PR DESCRIPTION
#### Description

This PR adds a temporary RC-switch-based override for EKF selector testing/debugging.

#### Purpose:

- allow forcing selection between MAIN (GPS) and BACKUP (TRN) estimator groups using AUX6
- provide immediate MAVLink feedback when estimator changes occur
- simplify in-flight validation of estimator switching behavior

#### Behavior:

AUX6 >= 0.5:
- artificially penalizes MAIN estimator instances
- forces selection of BACKUP (TRN)

AUX6 < 0.5:
- artificially penalizes BACKUP estimator instances
- forces selection of MAIN (GPS)

if RC signal is invalid/lost:
- override is disabled
- selector falls back to MAIN automatically

#### Notes:

- this is intentionally a hack/test utility
- not intended for merge