### PR TITLE
[Backport]Fix generate component regex escape sequence

### DIFF
--- a/src/lib/component_information/generate_component_general.py
+++ b/src/lib/component_information/generate_component_general.py
@@ -20,7 +20,7 @@ version_file = args.version_file
 version_dir = ''
 if version_file is not None:
     for line in open(version_file, "r"):
-        version_search = re.search('PX4_GIT_TAG_OR_BRANCH_NAME\s+"(.+)"', line)
+        version_search = re.search(r'PX4_GIT_TAG_OR_BRANCH_NAME\s+"(.+)"', line)
         if version_search:
             version_dir = version_search.group(1)
             break


### PR DESCRIPTION
While building a clean v1.15, I'm getting this annoying SyntaxWarning:


<img width="1163" height="157" alt="image" src="https://github.com/user-attachments/assets/2ba2d139-a0c4-40dc-a98c-86e6154199a3" />


This is Backport fix.  [Original PR for context](https://github.com/PX4/PX4-Autopilot/pull/23916)