### PR TITLE
Remove bias corrections from heading redundancy check

### DIFF
--- a/src/modules/aviant/navigation/Navigation.cpp
+++ b/src/modules/aviant/navigation/Navigation.cpp
@@ -229,8 +229,8 @@ void Navigation::checkMagHealthy(aviant_navigation_s *out, int estimator_instanc
 		return;
 	}
 
-	const matrix::Vector3f mag{estimator_aid_src_mag.observation[0], estimator_aid_src_mag.observation[1], estimator_aid_src_mag.observation[2]};
-	out->mag_heading = calculateMagHeading(estimator_states, mag);
+	const matrix::Vector3f debiased_mag{estimator_aid_src_mag.observation[0], estimator_aid_src_mag.observation[1], estimator_aid_src_mag.observation[2]};
+	out->mag_heading = calculateMagHeading(estimator_states, debiased_mag);
 }
 
 void Navigation::checkGnssPosFused(aviant_navigation_s *out, int estimator_instance)
@@ -244,7 +244,7 @@ void Navigation::checkGnssPosFused(aviant_navigation_s *out, int estimator_insta
 	out->ekf_gnss_pos_fused_recently = !isTimedOut(estimator_aid_src_gnss_pos.time_last_fuse, GNSS_TOUT);
 }
 
-float Navigation::calculateMagHeading(const estimator_states_s &states, const matrix::Vector3f &mag)
+float Navigation::calculateMagHeading(const estimator_states_s &states, const matrix::Vector3f &debiased_mag)
 {
 	// Modelled after Ekf::resetMagHeading
 	// see state.h in EKF for state index definitions
@@ -252,14 +252,14 @@ float Navigation::calculateMagHeading(const estimator_states_s &states, const ma
 	static_assert(sizeof(states.states) / sizeof(states.states[0]) == 24,
 		      "estimator_states_s size does not match expected EKF state size");
 	matrix::Vector3f mag_I{states.states[16], states.states[17], states.states[18]};
-	matrix::Vector3f mag_B{states.states[19], states.states[20], states.states[21]};
+	matrix::Vector3f mag_bias{states.states[19], states.states[20], states.states[21]};
 	matrix::Quaternionf attitude{states.states[0], states.states[1], states.states[2], states.states[3]};
 
 	// rotate the magnetometer measurements into earth frame using a zero yaw angle
 	const matrix::Dcmf R_to_earth = math::Utilities::updateYawInRotMat(0.f, matrix::Dcmf(attitude));
 
 	// the angle of the projection onto the horizontal gives the heading angle
-	const matrix::Vector3f mag_earth_pred = R_to_earth * (mag - mag_B);
+	const matrix::Vector3f mag_earth_pred = R_to_earth * (debiased_mag - mag_bias);
 
 	// note: we use the estimated inclination always, unlike EKF::getMagDeclination()
 	// this is for simplicity, since we expect mag to be aligned for most of the fligh

--- a/src/modules/aviant/navigation/Navigation.cpp
+++ b/src/modules/aviant/navigation/Navigation.cpp
@@ -259,7 +259,11 @@ float Navigation::calculateMagHeading(const estimator_states_s &states, const ma
 	const matrix::Dcmf R_to_earth = math::Utilities::updateYawInRotMat(0.f, matrix::Dcmf(attitude));
 
 	// the angle of the projection onto the horizontal gives the heading angle
-	const matrix::Vector3f mag_earth_pred = R_to_earth * (debiased_mag - mag_bias);
+	//
+	// we add back the bias that was previously subtracted. otherwise the
+	// estimated bias could hide bad calibrations. the estimated bias
+	// correction is not guaranteed to be accurate in all poses.
+	const matrix::Vector3f mag_earth_pred = R_to_earth * (debiased_mag + mag_bias);
 
 	// note: we use the estimated inclination always, unlike EKF::getMagDeclination()
 	// this is for simplicity, since we expect mag to be aligned for most of the fligh

--- a/src/modules/aviant/navigation/Navigation.hpp
+++ b/src/modules/aviant/navigation/Navigation.hpp
@@ -53,7 +53,7 @@ private:
 
 	int getEstimatorInstance();
 	bool isTimedOut(const hrt_abstime &timestamp, uint64_t timeout_interval) const;
-	static float calculateMagHeading(const estimator_states_s &states, const matrix::Vector3f &mag);
+	static float calculateMagHeading(const estimator_states_s &states, const matrix::Vector3f &debiased_mag);
 
 	static constexpr uint64_t EKF2_TOUT = 100_ms;
 	static constexpr uint64_t EKF2_SLOW_TOUT = 1100_ms; // Some EKF2 topics are published at 1 Hz


### PR DESCRIPTION
Today, we compare GNSS heading with magnetic heading to verify that we
are redundant to loss of GNSS heading. If the magnetic heading is off by
a lot, a loss of GNSS heading could cause positioning issues and maybe
position loss failsafe. However, the current code handled magnetometer
bias corrections wrong: it corrects for bias _two times_.

Instead of just removing the extra bias correction, this code goes
further: it undoes the bias correction completely. The reason is as
follows.

When flying, the drone compares GNSS heading with magnetic heading to
estimate magnetic sensor biases. Over time, the biases force the
bias-corrected mag heading to match the GNSS heading really well.
However, we don't know which biases would have been estimated if we lost
GNSS heading, so using them is "cheating".

Therefore we undo the debiasing in this commit. We compare GNSS heading
with just the statically calibrated magnetometer measurements.

The reason for this bug has one of two causes:
1. Either the author wanted to compare GNSS heading with bias-corrected
   magnetic heading, and they didn't notice that
   src/modules/ekf2/EKF/mag_fusion.cpp:74 already has corrected for the
   bias.
2. Or the author attempted to undo the debiasing, and just used the
   wrong sign (minus instead of plus).


The issue is clear here, in https://fms.aviant.no/flight/9232/show:
<img width="1359" height="628" alt="image" src="https://github.com/user-attachments/assets/08595e6b-bb2b-47a0-8063-f0bcc4e447e2" />

This PR also updates some naming to make it clearer what has already corrected biases or not, for readability.