### PR TITLE
navigator/feasibility: allow mid-mission takeoff commands

### DIFF
--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
@@ -54,7 +54,6 @@ void FeasibilityChecker::reset()
 	_fixed_wing_land_approach_failed = false;
 	_takeoff_land_available_failed = false;
 
-	_found_item_with_position = false;
 	_has_vtol_takeoff = false;
 	_has_takeoff = false;
 
@@ -350,45 +349,6 @@ bool FeasibilityChecker::checkTakeoff(mission_item_s &mission_item)
 		if (!_has_takeoff) {
 			_has_takeoff = true;
 		}
-
-
-		if (_found_item_with_position) {
-			mavlink_log_critical(_mavlink_log_pub, "Mission rejected: takeoff not first waypoint item\t");
-			events::send(events::ID("navigator_mis_takeoff_not_first"), {events::Log::Error, events::LogInternal::Info},
-				     "Mission rejected: takeoff is not the first waypoint item");
-			return false;
-		}
-	}
-
-	if (!_found_item_with_position) {
-		_found_item_with_position = (mission_item.nav_cmd != NAV_CMD_IDLE &&
-					     mission_item.nav_cmd != NAV_CMD_DELAY &&
-					     mission_item.nav_cmd != NAV_CMD_DO_JUMP &&
-					     mission_item.nav_cmd != NAV_CMD_DO_CHANGE_SPEED &&
-					     mission_item.nav_cmd != NAV_CMD_DO_SET_HOME &&
-					     mission_item.nav_cmd != NAV_CMD_DO_LAND_START &&
-					     mission_item.nav_cmd != NAV_CMD_DO_TRIGGER_CONTROL &&
-					     mission_item.nav_cmd != NAV_CMD_DO_DIGICAM_CONTROL &&
-					     mission_item.nav_cmd != NAV_CMD_IMAGE_START_CAPTURE &&
-					     mission_item.nav_cmd != NAV_CMD_IMAGE_STOP_CAPTURE &&
-					     mission_item.nav_cmd != NAV_CMD_VIDEO_START_CAPTURE &&
-					     mission_item.nav_cmd != NAV_CMD_VIDEO_STOP_CAPTURE &&
-					     mission_item.nav_cmd != NAV_CMD_DO_CONTROL_VIDEO &&
-					     mission_item.nav_cmd != NAV_CMD_DO_MOUNT_CONFIGURE &&
-					     mission_item.nav_cmd != NAV_CMD_DO_MOUNT_CONTROL &&
-					     mission_item.nav_cmd != NAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW &&
-					     mission_item.nav_cmd != NAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE &&
-					     mission_item.nav_cmd != NAV_CMD_DO_SET_ROI &&
-					     mission_item.nav_cmd != NAV_CMD_DO_SET_ROI_LOCATION &&
-					     mission_item.nav_cmd != NAV_CMD_DO_SET_ROI_WPNEXT_OFFSET &&
-					     mission_item.nav_cmd != NAV_CMD_DO_SET_ROI_NONE &&
-					     mission_item.nav_cmd != NAV_CMD_DO_SET_CAM_TRIGG_DIST &&
-					     mission_item.nav_cmd != NAV_CMD_OBLIQUE_SURVEY &&
-					     mission_item.nav_cmd != NAV_CMD_DO_SET_CAM_TRIGG_INTERVAL &&
-					     mission_item.nav_cmd != NAV_CMD_SET_CAMERA_MODE &&
-					     mission_item.nav_cmd != NAV_CMD_SET_CAMERA_ZOOM &&
-					     mission_item.nav_cmd != NAV_CMD_SET_CAMERA_FOCUS &&
-					     mission_item.nav_cmd != NAV_CMD_DO_VTOL_TRANSITION);
 	}
 
 	return true;

--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
@@ -124,7 +124,6 @@ private:
 	bool _items_fit_to_vehicle_type_failed{false};
 
 	// internal checkTakeoff related variables
-	bool _found_item_with_position{false};
 	bool _has_vtol_takeoff{false};
 	bool _has_takeoff{false};
 

--- a/src/modules/navigator/MissionFeasibility/FeasibilityCheckerTest.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityCheckerTest.cpp
@@ -238,22 +238,6 @@ TEST_F(FeasibilityCheckerTest, check_takeoff)
 	checker.processNextItem(mission_item, 0, 1);
 
 	ASSERT_EQ(checker.someCheckFailed(), false);
-
-
-	// takeoff item needs to be first item
-	checker.reset();
-	checker.publishLanded(true);
-	checker.publishHomePosition(0, 0, 100);
-
-	mission_item.nav_cmd = NAV_CMD_WAYPOINT;
-
-	checker.processNextItem(mission_item, 0, 2);
-
-	mission_item.nav_cmd = NAV_CMD_TAKEOFF;
-
-	checker.processNextItem(mission_item, 1, 2);
-
-	ASSERT_EQ(checker.someCheckFailed(), true);
 }
 
 TEST_F(FeasibilityCheckerTest, fixed_wing_land_approach)


### PR DESCRIPTION
In our operational workflow, a mid-mission takeoff command is intentionally used to execute a Fixed-Wing (FW) transition while strictly enforcing the aircraft's heading toward that specific takeoff point.

Because a recent update in PX4 v1.15 globally enforces the takeoff_first rule, missions utilizing this method are now immediately rejected upon upload. This PR removes that constraint to preserve this specialized transition alignment behavior.